### PR TITLE
chore(deps): upgrade benchmark Python dependencies

### DIFF
--- a/bench/locomo/requirements.txt
+++ b/bench/locomo/requirements.txt
@@ -1,6 +1,6 @@
-httpx>=0.27
-openai==1.54.3
-tqdm==4.66.3
-python-dateutil>=2.8
-nltk==3.9.3
-numpy>=1.24
+httpx>=0.28
+openai>=2.26
+tqdm>=4.67
+python-dateutil>=2.9
+nltk>=3.9
+numpy>=2.4

--- a/bench/longmemeval/requirements.txt
+++ b/bench/longmemeval/requirements.txt
@@ -1,3 +1,3 @@
-httpx>=0.27
-openai==1.54.3
-tqdm
+httpx>=0.28
+openai>=2.26
+tqdm>=4.67


### PR DESCRIPTION
## Summary
- Upgrade openai SDK from 1.x to 2.x (API unchanged for `chat.completions.create`)
- Upgrade tqdm, nltk, numpy, httpx to latest versions
- Switch from pinned (`==`) to minimum (`>=`) version constraints for flexibility

## Test plan
- [x] Verify LoCoMo benchmark harness runs with new deps
- [x] Verify LongMemEval benchmark harness runs with new deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)