### PR TITLE
docs: update stale docs, remove volatile numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,12 @@ The team lead has all 32 codemem tools + team orchestration. Specialized agents 
 - **Cross-session patterns**: Detects repeated searches, file hotspots, decision chains, tool preferences across sessions
 - **Diff-aware memory**: Computes semantic diff summaries (function additions/removals, import changes, type definitions)
 - **File watching**: Real-time notify-based watcher (<50ms debounce) with auto-indexing
-- **Session continuity**: Session tracking with start/end/list, auto-started by lifecycle hooks
+- **Session continuity**: Session tracking with start/end/list, auto-started by lifecycle hooks. `session_id` field on `MemoryNode` auto-populated from `CodememEngine::active_session_id`. `memory_count` computed via correlated subquery. MCP activity recording for all tools. Checkpoint persistence with rich metadata (session_id, memory_count, action counts, patterns, hot directories)
 - **Consolidation**: 5 cycles — Decay (power-law, daily), Creative/REM (vector KNN O(n log n), weekly), Cluster (semantic cosine + union-find, monthly), Summarize (LLM-powered, on-demand), Forget (optional)
 - **Self-editing memory**: refine_memory (EVOLVED_INTO provenance), split_memory (PART_OF edges), merge_memories (SUMMARIZES edges) — all with full store pipeline and temporal edge tracking
 - **Temporal edges**: Edges have `valid_from`/`valid_to` fields for tracking when relationships are active
 - **Pattern confidence**: Log-scaled confidence based on `ln(frequency)/ln(total_sessions)` instead of linear `count/N`
-- **Storage**: Single database at ~/.codemem/codemem.db + ~/.codemem/codemem.idx, namespace-scoped queries
+- **Storage**: Single database at ~/.codemem/codemem.db + ~/.codemem/codemem.idx, namespace-scoped queries. Multi-row INSERT batching (SQLite 999-param limit aware), transaction wrapping (`begin/commit/rollback_transaction` on StorageBackend with `AtomicBool` guard), batch cascade deletes for consolidation
 - **13 node kinds**: File, Package, Function, Method, Class, Interface, Type, Constant, Module, Memory, Endpoint, Test, Chunk
 - **Graph compaction**: Two-pass pruning after indexing — chunks scored by centrality + structural parent + memory link + content density, symbols scored by call connectivity + visibility + kind + memory link + code size. Cold-start-aware: when no memories exist, memory_link weight is redistributed to other factors. Configurable via `ChunkingConfig`
 - **14 enrichment types**: git history, security, performance, complexity (cyclomatic/cognitive), architecture inference, test mapping, API surface, doc coverage, change impact, code smells, hot+complex correlation, blame/ownership, advanced security scanning, quality stratification. All produce Insight memories tagged `static-analysis`
@@ -92,7 +92,7 @@ candle-core/nn/transformers (ML inference), usearch (HNSW), rusqlite (bundled SQ
 
 ```bash
 cargo build                    # Build all crates
-cargo test --workspace         # Run all tests (755 tests)
+cargo test --workspace         # Run all tests
 cargo bench                    # Run benchmarks
 cargo build --release          # Optimized release binary
 cargo install --path crates/codemem      # Install CLI binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ cargo build
 ## Test
 
 ```bash
-cargo test --workspace       # All 415 tests
+cargo test --workspace       # All tests
 cargo bench                  # Criterion benchmarks
 ```
 
@@ -31,27 +31,34 @@ cargo run -- serve           # Start MCP server (stdio)
 
 ## Project Structure
 
-Codemem is a Cargo workspace with 12 crates. See [docs/architecture.md](docs/architecture.md) for the full design.
+Codemem is a Cargo workspace with 6 crates. See [docs/architecture.md](docs/architecture.md) for the full design.
 
 | Crate | When to modify |
 |-------|---------------|
-| codemem-core | Adding/changing memory types, traits, scoring weights, shared types |
-| codemem-storage | Changing SQLite schema, queries, persistence logic, session management |
-| codemem-vector | Changing HNSW parameters, distance metrics, vector index behavior |
-| codemem-graph | Adding graph algorithms, relationship types, traversal logic, centrality caching |
+| codemem-core | Adding/changing memory types, traits, scoring weights, shared types, config |
+| codemem-storage | Changing SQLite schema, queries, persistence logic, graph algorithms, HNSW parameters, session management |
 | codemem-embeddings | Adding embedding providers (Candle/Ollama/OpenAI), cache behavior |
-| codemem-index | Adding language extractors, tree-sitter parsing, reference resolution |
-| codemem-mcp | Adding/modifying MCP tools, JSON-RPC handling, BM25 scoring, pattern detection |
-| codemem-hooks | Adding tool extractors, diff computation, changing ingest behavior |
-| codemem-cli | Adding CLI commands, changing command-line interface |
-| codemem-watch | File watcher behavior, ignore patterns, debounce settings |
+| codemem-engine | Domain logic: indexing, hooks, enrichment, consolidation, recall, search, patterns, compression |
+| codemem | Adding/modifying MCP tools, REST API routes, CLI commands, lifecycle hooks |
 | codemem-bench | Adding benchmarks, changing performance targets |
+
+## Web UI
+
+The React dashboard lives in `ui/`. Uses Bun as package manager.
+
+```bash
+cd ui && bun install            # Install dependencies
+cd ui && bun run dev            # Dev server (Vite)
+cd ui && bun run build          # Production build
+cd ui && bun run tsc --noEmit   # TypeScript check
+cd ui && bun run eslint .       # Lint check
+```
 
 ## Code Style
 
 - Run `cargo fmt` before committing
-- Run `cargo clippy` and address all warnings
-- Prefer `Result<T, E>` over panicking
+- Run `cargo clippy --workspace --all-targets -- -D warnings` and address all warnings (CI treats warnings as errors)
+- Prefer `Result<T, E>` over panicking — zero `.unwrap()` on locks in production code
 - Keep functions focused and under ~50 lines where practical
 
 ## Testing
@@ -59,6 +66,7 @@ Codemem is a Cargo workspace with 12 crates. See [docs/architecture.md](docs/arc
 - Unit tests live alongside code (`#[cfg(test)]` modules)
 - Integration tests in `crates/*/tests/`
 - Benchmarks in `crates/codemem-bench/` using Criterion
+- UI E2E tests via Playwright
 - New features should include tests
 
 ## Performance
@@ -83,7 +91,7 @@ test(graph): add Louvain community detection coverage
 
 1. Fork and create a feature branch from `main`
 2. Make changes with tests
-3. Run `cargo fmt && cargo clippy && cargo test --workspace`
+3. Run `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`
 4. Open a PR with a clear description
 
 ## Architecture Decisions

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ See [CLI Reference](docs/cli-reference.md) for full usage.
 git clone https://github.com/cogniplex/codemem.git
 cd codemem
 cargo build --release          # Optimized binary at target/release/codemem
-cargo test --workspace         # Run all 755 tests
+cargo test --workspace         # Run all tests
 cargo bench                    # Criterion benchmarks
 ```
 

--- a/crates/codemem-core/README.md
+++ b/crates/codemem-core/README.md
@@ -9,7 +9,7 @@ This is the foundation crate with zero internal dependencies. All other Codemem 
 ## Key Exports
 
 - **Types** (`types.rs`): `MemoryNode`, `Edge`, `Session`, `DetectedPattern`, `ScoringWeights`, `VectorConfig`, `GraphConfig`
-- **Enums**: `MemoryType` (7 variants), `RelationshipType` (23 variants), `NodeKind` (12 variants), `PatternType` (5 variants)
+- **Enums**: `MemoryType` (7 variants), `RelationshipType` (24 variants), `NodeKind` (13 variants), `PatternType` (5 variants)
 - **Traits** (`traits.rs`): `VectorBackend`, `GraphBackend`, `StorageBackend`
 - **Config** (`config.rs`): `CodememConfig`, `EmbeddingConfig`, `StorageConfig` — TOML-backed persistent configuration
 - **Errors** (`error.rs`): `CodememError` with variants for storage, embedding, graph, config, lock poisoning, and more

--- a/crates/codemem-engine/README.md
+++ b/crates/codemem-engine/README.md
@@ -1,31 +1,41 @@
 # codemem-engine
 
-ast-grep based code indexing for 14 languages with incremental change detection.
+Domain logic engine for the Codemem memory system.
 
 ## Overview
 
-Parses source files to extract symbols (functions, structs, classes, methods, interfaces, constants) and their references (calls, imports, implements, inherits). Uses a unified `AstGrepEngine` driven by compile-time embedded YAML rules. Produces structured data that feeds into the knowledge graph.
+`CodememEngine` is the central struct that holds all backends (storage, embeddings, graph) and orchestrates all domain operations. It handles code indexing, memory persistence, recall, enrichment, consolidation, and session management.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `index/` | ast-grep code indexing for 14 languages, YAML-driven rules, manifest parsing, reference resolution |
+| `hooks/` | Lifecycle hook handlers for tool types (Read/Glob/Grep/Edit/Write/Bash/WebFetch/WebSearch/Agent/ListDir), trigger-based auto-insights |
+| `watch/` | Real-time file watcher with <50ms debounce and .gitignore support |
+| `enrichment/` | 14 enrichment analyses (git history, security, performance, complexity, etc.) |
+| `consolidation/` | 5 neuroscience-inspired cycles: decay, creative, cluster, forget, summarize |
+| `persistence/` | Index persistence pipeline with batched graph/embedding inserts and compaction |
+| `analysis.rs` | Decision chains, session checkpoints, impact analysis |
+| `search.rs` | Semantic, text, and hybrid code search |
+| `recall.rs` | Unified recall with temporal edge filtering and hybrid scoring |
+| `memory_ops.rs` | Memory CRUD with transaction wrapping and session_id auto-population |
+| `bm25.rs` | Okapi BM25 scoring with code-aware tokenizer and serialization |
+| `scoring.rs` | 8-component hybrid scoring helpers |
+| `patterns.rs` | Cross-session pattern detection |
+| `compress.rs` | Optional LLM observation compression |
+| `metrics.rs` | Operational metrics (latency percentiles, call counters) |
 
 ## Supported Languages
 
-Rust (.rs), TypeScript/JavaScript (.ts/.tsx/.js/.jsx), Python (.py), Go (.go), C/C++ (.c/.h/.cpp/.hpp), Java (.java), Ruby (.rb), C# (.cs), Kotlin (.kt/.kts), Swift (.swift), PHP (.php), Scala (.scala/.sc), HCL/Terraform (.tf/.hcl)
-
-## Key Types
-
-- `Indexer` — Main pipeline: walks directories, parses files, detects changes
-- `CodeParser` — ast-grep parsing coordinator
-- `AstGrepEngine` — Unified extraction engine with YAML-driven rules for all languages
-- `ReferenceResolver` — Maps references to qualified names, produces graph edges
-- `Symbol` — Extracted code entity (name, kind, signature, visibility, file, line range, doc comment)
-- `Reference` — Cross-symbol reference (source, target, kind: Call/Import/Inherits/Implements/TypeUsage)
-- `ChangeDetector` — SHA-256 file hashing for incremental re-indexing
+Rust, TypeScript/JavaScript/JSX/TSX, Python, Go, C/C++, Java, Ruby, C#, Kotlin, Swift, PHP, Scala, HCL/Terraform
 
 ## Data Flow
 
 ```
-Directory → Walk → Parse (ast-grep) → Symbols + References
-                                            ↓
-                                  ReferenceResolver
-                                            ↓
-                                  ResolvedEdges (CALLS, IMPORTS, INHERITS, ...)
+Source Files → Index (ast-grep) → Persist (nodes, edges, embeddings) → Compact
+                                                                         ↓
+Hooks (tool observations) → Extract → Embed → Store ←── Enrich (14 analyses)
+                                                         ↓
+                                              Recall (hybrid scoring) → Results
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ flowchart TD
 | Crate | Description |
 |-------|-------------|
 | codemem-core | Shared types (`types.rs`: `MemoryNode`, `Edge`, `Session`, `DetectedPattern`), traits (`traits.rs`: `VectorBackend`/`GraphBackend`/`StorageBackend`), errors (`error.rs`), config (`config.rs`: `CodememConfig`, `ChunkingConfig`, `EnrichmentConfig` TOML persistence). 7 `MemoryType`s, 5 `PatternType`s, 24 `RelationshipType`s, 13 `NodeKind`s, `ScoringWeights` |
-| codemem-storage | rusqlite (bundled) WAL mode + usearch HNSW vector index + petgraph graph engine. Split into `memory.rs` (CRUD), `graph_persistence.rs` (nodes/edges/embeddings), `queries.rs` (stats/sessions/patterns), `backend.rs` (StorageBackend trait impl), `migrations.rs` (schema versioning), `vector.rs` (HNSW 768-dim cosine, M=16, efConstruction=200), `graph/` (traversal with BFS/DFS/kind-aware filtering, algorithms: PageRank, Louvain, SCC, betweenness, topological, cached centrality, graph compaction, package nodes) |
+| codemem-storage | rusqlite (bundled) WAL mode + usearch HNSW vector index + petgraph graph engine. Split into `memory.rs` (CRUD), `graph_persistence.rs` (nodes/edges/embeddings), `queries.rs` (stats/sessions/patterns), `backend.rs` (StorageBackend trait impl with multi-row INSERT batching, transaction wrapping via `begin/commit/rollback_transaction`), `migrations.rs` (schema versioning), `vector.rs` (HNSW 768-dim cosine, M=16, efConstruction=200), `graph/` (traversal with BFS/DFS/kind-aware filtering, algorithms: PageRank, Louvain, SCC, betweenness, topological, cached centrality, graph compaction, package nodes) |
 | codemem-embeddings | Pluggable embedding providers via `EmbeddingProvider` trait + `from_env()` factory: Candle (pure Rust ML, default), Ollama (local HTTP), OpenAI-compatible (Voyage AI, Together, Azure, etc.). `CachedProvider` wrapper adds LRU cache (10K) to remote providers. BAAI/bge-base-en-v1.5 (768-dim), mean pooling, L2 normalization. Safe concurrency via `LockPoisoned` error handling |
 | codemem-engine | Domain logic engine: `CodememEngine` struct holds all backends. Modules: `index/` (ast-grep code indexing, 14 languages, YAML-driven rules, manifest parsing, reference resolution), `hooks/` (PostToolUse JSON parser, per-tool extractors for 9 tool types, diff-aware memory, trigger-based auto-insights), `watch/` (real-time file watcher, <50ms debounce, .gitignore support), `enrichment/` (14 enrichment types, one file per analysis + `run_enrichments()` pipeline), `consolidation/` (5 cycles: decay, creative, cluster, forget, summarize), `persistence/` (index persistence + compaction), `analysis.rs` (decision chains, session checkpoints, impact analysis), `search.rs` (semantic/text/hybrid code search), `recall.rs` (unified recall with temporal edge filtering), `bm25.rs` (Okapi BM25 scoring with serialization), `scoring.rs` (hybrid scoring helpers), `patterns.rs` (cross-session pattern detection), `compress.rs` (LLM observation compression), `metrics.rs` (operational metrics) |
 | codemem | Unified binary + library. Three transport modules: `mcp/` (JSON-RPC stdio + HTTP server, 32 MCP tools, scoring, types), `api/` (REST/SSE API with Axum, routes for memories/graph/vectors/stats/patterns/insights/agents/config/timeline/namespaces/sessions, PCA point cloud, embedded React UI), `cli/` (clap derive, 19 commands, lifecycle hooks, config management, multi-format export) |
@@ -537,12 +537,13 @@ The schema is managed by versioned, idempotent migrations tracked in a `schema_v
 | `content_hash` | TEXT | SHA-256 for deduplication |
 | `tags` | TEXT | JSON array of tag strings |
 | `metadata` | TEXT | JSON object of arbitrary key-value pairs |
+| `session_id` | TEXT | FK to `sessions.id`, auto-populated from active session (nullable) |
 | `namespace` | TEXT | Project path for scoped queries (nullable) |
 | `created_at` | INTEGER | Unix timestamp |
 | `updated_at` | INTEGER | Unix timestamp |
 | `last_accessed_at` | INTEGER | Unix timestamp |
 
-Indexes: `memory_type`, `content_hash`, `importance`, `created_at`, `namespace`.
+Indexes: `memory_type`, `content_hash`, `importance`, `created_at`, `namespace`, `session_id`.
 
 ### `memory_embeddings` table
 
@@ -774,7 +775,7 @@ For production use, the contextual enrichment step (Section 6) runs before step 
 
 ---
 
-## 12. MCP Tools (28 primary + legacy aliases)
+## 12. MCP Tools (32)
 
 ### Memory CRUD (7)
 | Tool | Description |
@@ -798,12 +799,14 @@ For production use, the contextual enrichment step (Section 6) runs before step 
 | `get_symbol_info` | Get symbol details, optionally with graph dependencies |
 | `get_symbol_graph` | Symbol dependency graph and impact analysis (replaces `get_dependencies`/`get_impact`) |
 
-### Graph Analysis (3)
+### Graph Analysis (5)
 | Tool | Description |
 |------|-------------|
-| `find_important_nodes` | PageRank to find most central nodes (replaces `get_pagerank`) |
-| `find_related_groups` | Louvain community detection (replaces `get_clusters`) |
+| `find_important_nodes` | PageRank to find most central nodes |
+| `find_related_groups` | Louvain community detection |
 | `get_cross_repo` | Cross-package dependency analysis (Cargo.toml, package.json, go.mod, pyproject.toml) |
+| `get_node_memories` | Get memories linked to a specific graph node |
+| `node_coverage` | Coverage analysis: which graph nodes have associated memories |
 
 ### Consolidation & Patterns (3)
 | Tool | Description |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,6 +1,6 @@
 # Comparison: Memory Tools for AI Coding Assistants
 
-A comprehensive comparison of Codemem v0.8.0 against other memory and context tools in the ecosystem. Last updated March 2026.
+A comprehensive comparison of Codemem against other memory and context tools in the ecosystem. Last updated March 2026.
 
 ## At a Glance
 
@@ -14,7 +14,7 @@ A comprehensive comparison of Codemem v0.8.0 against other memory and context to
 | **Offline** | Yes | Partial | Partial | No | No | Partial | Partial | No | No | Partial (Ollama) |
 | **Embedding** | Pluggable: Candle (local), Ollama, OpenAI-compatible (768-dim) | Chroma (via uvx) | Pluggable (24+ providers) | Built-in | Pluggable (OpenAI, etc.) | Configurable | Pluggable | OpenAI/Voyage/Ollama | Qdrant + Voyage AI | OpenAI, Gemini, Ollama |
 | **Code-aware** | Yes (ast-grep + CST chunking) | No | No | Partial (code connector) | No | Yes (Letta Code) | Partial (codify) | Yes (AST splitting) | No | No |
-| **MCP tools** | 30 | 3 | Yes (OpenMemory MCP) | Yes (plugin) | Yes (Graphiti MCP) | Yes | Yes (cognee-mcp) | 4 | 4 | Yes |
+| **MCP tools** | 32 | 3 | Yes (OpenMemory MCP) | Yes (plugin) | Yes (Graphiti MCP) | Yes | Yes (cognee-mcp) | 4 | 4 | Yes |
 | **Graph** | Built-in (petgraph, 25 algos) | No | Neo4j (optional) | No | Neo4j/FalkorDB/Kuzu | No | Neo4j/FalkorDB/Kuzu | No | FalkorDB | Temporal KG |
 | **Compression** | Pluggable LLM (optional) | AI-powered (always on) | No | No | No | No | No | No | No | No |
 | **Consolidation** | 5 cycles (decay/creative/cluster/summarize/forget) | No | Auto-extraction | Contradiction handling | Temporal updates | Self-editing memory | ECL pipeline | No | HippoRAG-inspired | Adaptive decay |
@@ -147,7 +147,7 @@ A comprehensive comparison of Codemem v0.8.0 against other memory and context to
 | **Contextual embeddings** | Metadata + graph neighbors enriched before embedding | Raw text embedding |
 | **Consolidation** | 5 biologically-inspired cycles (decay/creative/cluster/summarize/forget) | None |
 | **Self-editing** | Yes (refine/split/merge with provenance chains) | No |
-| **MCP tools** | 28 | 3 (search, timeline, get_observations) |
+| **MCP tools** | 32 | 3 (search, timeline, get_observations) |
 | **Session insights** | Auto-generated (trigger-based) + session_checkpoint tool | None (manual only) |
 | **Web viewer** | PCA visualization dashboard | React UI with SSE, infinite scroll, Endless Mode (beta) |
 | **Privacy** | Namespace scoping | `<private>` tag exclusion |

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -79,6 +79,8 @@ Each symbol and file becomes a graph node with kind-specific attributes:
 - `pkg:src/` (kind: Package)
 - `chunk:src/main.rs:10-25` (kind: Chunk)
 
+Nodes are persisted via multi-row INSERT batching (respecting SQLite's 999-parameter limit).
+
 ### 2b. Graph Edges
 
 Resolved references become weighted edges. Edge weights are computed by `edge_weight_for()` based on relationship type:
@@ -88,13 +90,15 @@ Resolved references become weighted edges. Edge weights are computed by `edge_we
 - DEPENDS_ON: 0.5
 - etc.
 
+Edges are also batched via multi-row INSERT.
+
 ### 2c. Embeddings
 
 Symbols and chunks are embedded using the configured provider (Candle/Ollama/OpenAI). Text is contextually enriched before embedding:
 - Symbol: qualified name + kind + file path + doc comment excerpt
 - Chunk: file path + parent symbol + content
 
-Embeddings are batched (chunks of 64) and inserted into both the HNSW vector index and SQLite storage.
+Embeddings are batched (chunks of 64) and inserted into both the HNSW vector index (via batch insert) and SQLite storage (via multi-row INSERT). The embedding mutex is acquired per-batch rather than for the full pipeline to reduce lock contention.
 
 ### 2d. Compaction
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,337 @@
+# Codemem Roadmap
+
+A living roadmap for Codemem's evolution from a developer-local single binary to a hosted team-friendly code memory platform. Last updated March 2026.
+
+## Why Now?
+
+The AI coding assistant market is exploding — Cursor, Windsurf, Claude Code, Copilot Workspace. Every one of them loses context between sessions. Memory is the obvious missing piece, and the timing window is narrow: once a dominant memory layer emerges, switching costs lock developers in.
+
+Codemem's advantage is not just features — it's architectural. A single Rust binary with zero runtime dependencies can ship everywhere these assistants run: local machines, CI pipelines, air-gapped environments, containers. No other tool in the space can make that claim.
+
+## Strategic Arc
+
+```
+Viral demo --> credibility + community --> daily-driver UX --> hosted team mode --> expand
+```
+
+## Competitive Context
+
+The AI memory space is crowded and well-funded (Mem0 $24M, Cognee $7.5M, Supermemory $3M). See [comparison.md](comparison.md) for detailed analysis. Codemem's differentiators:
+
+- **Single Rust binary, zero runtime deps** — every competitor needs Python/Node.js + external databases
+- **Offline-first** — fully functional with local Candle BERT
+- **Code-aware structural intelligence** — 14 language extractors with CST-aware chunking
+- **Deep graph algorithms** — 25 algorithms (PageRank, Louvain, betweenness, SCC) built-in
+- **Self-editing memory** — refine/split/merge with provenance tracking
+- **8-component hybrid scoring** — vector + graph strength + BM25 + temporal + tags + importance + confidence + recency
+
+Gaps to close: no published benchmarks, no multi-modal support, no team/hosted mode, local-only scaling limits on large monorepos (redundant indexing across developer machines), no community infrastructure.
+
+## Adoption Funnel
+
+Every phase should move developers through this funnel:
+
+```
+Discover (HN post, demo video, MCP registry)
+  --> Try (brew install, 5-min getting started)
+    --> Use daily (incremental indexing, fast recall)
+      --> Contribute (good first issues, Discord)
+        --> Advocate (share, blog, talk)
+```
+
+---
+
+## Phase 0: Viral Proof Point (~4-6 weeks)
+
+**Goal**: Create one demo that sells the project in 30 seconds.
+
+Before benchmarks, before docs, before anything else — build something shareable that makes developers say "I need this."
+
+### Demo Candidates (pick one or two)
+
+**Repo onboarding demo**: Point Codemem at a well-known OSS repo (e.g., ripgrep, axum, or tokio), run `codemem index` + `codemem enrich`, then ask architectural questions through MCP recall. Show it answering questions that would take a human hours to figure out. Screen recording for Twitter/YouTube/HN.
+
+**Session replay demo**: Record a 10-minute coding session where the developer explores a codebase. Close the session. Open a new one. Show Codemem recalling the full context — what files were read, what patterns were noticed, what decisions were made — without re-exploration.
+
+**Interactive playground**: A hosted web demo where visitors can explore a pre-indexed repo's knowledge graph in the React UI. Zero install, instant value. Pre-index 3-5 popular repos for visitors to browse.
+
+### Launch Sequence
+
+1. Record demo video (< 2 minutes)
+2. Write HN "Show HN" post with the video
+3. Post to relevant subreddits (r/rust, r/programming, r/ChatGPTCoding)
+4. Submit to MCP tool registries
+
+---
+
+## Phase 1: Credibility and Community (v0.9 - v1.0, ~3 months)
+
+**Goal**: Establish trust and build the first community of daily users.
+
+### Benchmarks
+
+- Run LoCoMo and LongMemEval benchmark suites
+- Publish results in README and comparison doc
+- Even mid-pack results are compelling when paired with "zero deps, offline, <100ms startup"
+- Establish a repeatable benchmark CI job so results stay current
+
+### Community Infrastructure
+
+| Item | Why |
+|------|-----|
+| CONTRIBUTING.md with "good first issues" | Lower the barrier to first PR |
+| Discord server | Real-time community, support, feedback |
+| Weekly changelog / dev blog | Show momentum, attract attention |
+| GitHub Discussions enabled | Async Q&A, feature requests |
+| "Awesome codemem" examples | Show real-world usage patterns |
+| Sponsor button / Open Collective | Signal longevity, fund hosting costs |
+| Architecture walkthrough | Converts curious developers into PR authors — explain the crate structure, data flow, and where to start hacking |
+
+### Distribution
+
+- MCP registry listing (official MCP tool directory)
+- Claude Code / Cursor / Windsurf plugin marketplace presence
+- Polish Homebrew tap (`brew install cogniplex/tap/codemem`)
+
+### Documentation
+
+- Getting-started guide (first 5 minutes to value)
+- MCP tool API reference (all 32 tools with examples)
+- Architecture walkthrough for contributors
+
+### Stability
+
+- ~~Freeze MCP tool surface at 32 tools~~ ✅ Done
+- ~~Session continuity polish (metadata tracking, checkpoint reliability)~~ ✅ Done — session_id on memories, memory_count via correlated subquery, checkpoint persistence with rich metadata
+- ~~Persistence pipeline performance (batch inserts for graph nodes/edges/embeddings)~~ ✅ Done — multi-row INSERT batching, transaction wrapping, vector batch insert, embedding mutex scope reduction
+
+### Testing
+
+Focus on tests that catch real problems, not coverage numbers:
+
+- Integration tests for the critical path: index -> recall -> consolidate
+- Regression tests for bugs users actually hit
+- Cross-platform CI: add Windows to existing ubuntu + macos matrix
+
+---
+
+## Phase 2: Daily-Driver UX (v1.x, ~3 months)
+
+**Goal**: Make Codemem reliable enough that developers use it every day without thinking about it.
+
+### Incremental Indexing
+
+The #1 UX pain point for daily use. Currently, re-indexing means re-scanning the entire codebase.
+
+- File watching + diff-based re-index — only process changed files
+- Track file content hashes to skip unchanged files on startup
+- Dependents-aware: when `foo.rs` changes, re-resolve references in files that import from it
+- Target: re-index a single file change in < 1 second
+
+### Config UX
+
+- Sensible defaults that work out of the box for common project types
+- Project-local `.codemem.toml` config (currently only global `~/.codemem/config.toml`)
+- Auto-detect project type and apply appropriate settings (Rust project? Set namespace to crate name, configure Rust-specific enrichments)
+
+### Better ast-grep Rules
+
+Rather than replacing ast-grep now, improve it incrementally:
+
+- Add languages users request (based on GitHub issues / Discord feedback)
+- Improve cross-file heuristics (better import resolution within ast-grep's pattern model)
+- Community-contributed rule sets for popular frameworks
+
+### Recall Quality
+
+Concrete feedback signal: when a memory is recalled and the user's next action references its content (e.g., the memory mentions `AuthService` and the next Edit/Read targets `auth_service.rs`), count that as a "used" signal. When the user re-asks the same question within a session, count the prior recall as a miss.
+
+- Instrument PostToolUse hook to detect content overlap between recalled memories and subsequent tool targets
+- Track used/missed ratio per memory and per scoring component
+- Tune scoring weights based on real usage data (increase weight of components that correlate with "used" signals)
+- Surface confidence scores so users know when to trust vs. verify
+
+---
+
+## Phase 3: Storage Abstraction and Team Mode (v2.x, ~6 months)
+
+**Goal**: One team member (or CI) indexes, everyone benefits. Solve the monorepo redundancy problem.
+
+### Storage Backend: Postgres + pgvector
+
+For team/hosted mode, use PostgreSQL + pgvector — battle-tested, every team already runs Postgres, every cloud provider has managed instances, and pgvector is the production standard for vector search.
+
+**Why Postgres, not SurrealDB:**
+
+| Concern | Postgres | SurrealDB |
+|---------|----------|-----------|
+| Production maturity | Decades | Still maturing |
+| Community size | Massive (contributors know it) | Growing but small |
+| Cloud availability | Every provider has managed Postgres | Limited managed offerings |
+| Vector search | pgvector is the industry standard | Native HNSW but less battle-tested |
+| Graph queries | Recursive CTEs or Apache AGE extension | Native record links |
+| Ops knowledge | Your users' ops teams already know it | Learning curve |
+| Migration tooling | SQLite -> Postgres is well-understood | Novel migration path |
+
+SurrealDB is architecturally elegant but practically risky for a core dependency. If it matures significantly, it can be added as a third backend later behind the existing trait abstraction.
+
+**Architecture:**
+
+- **Local mode (default)**: SQLite + usearch + petgraph — unchanged, keep what works
+- **Team mode**: Postgres (documents + metadata) + pgvector (embeddings + HNSW) + petgraph materialization (graph algorithms)
+- Feature flag: `--features postgres` adds the team backend. Default build stays zero-dep
+
+**Implementation plan:**
+
+1. Audit and extend `StorageBackend`, `VectorBackend`, `GraphBackend` traits in codemem-core to cover all raw backend calls
+2. New `codemem-postgres` crate implementing all three traits
+3. Migration tooling: SQLite -> Postgres data migration
+4. Graph algorithms: keep petgraph as compute layer, materialize subgraphs from Postgres on demand (Postgres doesn't have PageRank built-in)
+
+### Shared Indexing via CI
+
+The primary use case for team mode:
+
+1. CI pipeline runs `codemem index` + `codemem enrich` on push to main
+2. Developers connect to the shared Postgres instance for recall
+3. No local indexing needed for large monorepos
+4. Individual developers can still store personal memories (scoped to their user within the namespace)
+
+```bash
+# Local mode (default, current behavior)
+codemem serve
+
+# Team mode (connect to shared Postgres)
+codemem serve --postgres postgres://codemem:pass@team-db:5432/codemem
+```
+
+### Auth and Permissions
+
+Map to Postgres roles:
+
+- **Reader** — recall, search, graph traversal (most developers)
+- **Writer** — store memories, refine, split, merge
+- **Admin** — index, enrich, consolidate, configure
+
+### Memory Conflict Resolution
+
+When multiple developers store memories for the same namespace:
+
+- **Code structure** (facts from indexing) — CI is authoritative, last-write-wins
+- **Insights** (observations, patterns) — append, all perspectives kept
+- **Decisions** — append with authorship, build decision chains
+
+### Sustainability
+
+Team mode implies infrastructure costs (Postgres hosting, CI compute). Funding options, not mutually exclusive:
+
+- **GitHub Sponsors / Open Collective** — individual and corporate sponsorship (set up in Phase 1)
+- **Paid hosted tier** — managed Codemem instance with Postgres, CI indexing, and SSO. Free for open-source repos, paid for private repos
+- **Support / consulting** — paid onboarding and integration support for teams adopting Codemem at scale
+
+The core project stays Apache 2.0 and fully functional in local mode. Hosted features are open-source too — the paid tier is the managed infrastructure, not the software.
+
+### Deployment
+
+```bash
+# Docker compose
+docker compose up  # Postgres + pgvector + codemem serve
+
+# Or connect to existing Postgres
+codemem serve --postgres postgres://user:pass@host:5432/codemem
+```
+
+---
+
+## Phase 4: LSP and Expand (v2.x+)
+
+**Goal**: Replace pattern-based parsing with editor-grade intelligence, broaden beyond code-only memory.
+
+### LSP-Based Symbol Resolution
+
+Replace ast-grep with Language Server Protocol — only after proving demand and having engineering bandwidth. LSP is high-effort, high-reward, but not urgent.
+
+**What LSP gives over ast-grep:**
+
+- **Cross-file symbol resolution** — follow imports to definitions, resolve trait implementations to concrete types. Graph edges (IMPORTS, CALLS, IMPLEMENTS) become precise instead of heuristic
+- **Type-aware context** — embed return types and parameter types in contextual embeddings
+- **Workspace-wide references** — find all callers across the entire monorepo
+- **Language coverage** — rust-analyzer, typescript-language-server, pyright, gopls, clangd all speak the same protocol
+
+**Architecture: two layers, not two systems:**
+
+- **Tree-sitter** for structure — parse syntax trees to identify function/class/method boundaries for chunking. Lightweight, works on any file with zero project setup
+- **LSP** for semantics — resolve references, types, cross-file edges. Requires the project to be buildable
+
+Tree-sitter handles "where are the chunks?" and LSP handles "how do the chunks relate?" This is a parse-then-resolve pipeline, not two parallel extraction systems.
+
+**Tradeoff:** LSP servers are heavyweight (rust-analyzer uses 2GB+ RAM on large repos). This reinforces the team/hosted mode value — run LSP indexing once on CI, not on every developer machine.
+
+**Transition plan:**
+
+1. Implement LSP integration using `textDocument/documentSymbol`, `textDocument/references`, `textDocument/definition`
+2. Validate per-language that LSP matches or exceeds ast-grep quality
+3. Remove ast-grep rules language by language
+4. Keep tree-sitter as fallback for when LSP can't start
+
+### Document Ingestion
+
+- PDF, markdown, and Notion import — chunk and embed alongside code
+- Useful for design docs, RFCs, ADRs, runbooks that reference code
+- Link document memories to code graph nodes
+
+### GitHub / GitLab Integration
+
+Webhook-driven memory capture:
+
+- PR opened: index the diff, store change summary
+- PR merged: store decision memory with context
+- Issue closed: capture resolution as insight
+- Review comment: extract patterns and preferences
+
+### IDE Extensions
+
+- VS Code and JetBrains extensions
+- Inline "what does Codemem know about this file/function?" in the editor
+- Graph neighbors, related memories, recent changes in a sidebar
+
+### Smarter Recall
+
+- Cross-encoder re-ranking for top-k results (lightweight model, runs after initial retrieval)
+- Query expansion using graph neighbors and synonyms from the knowledge graph
+- Adaptive scoring weights that learn from the Phase 2 feedback signals
+- Context-aware recall thresholds (tighter for focused queries, broader for exploration)
+
+### Cross-Repo Knowledge
+
+- With team mode, enable `get_cross_repo` to traverse memories across repositories
+- Shared patterns and decisions across the organization's codebase
+
+---
+
+## Milestones
+
+| Milestone | Target | Metric |
+|-----------|--------|--------|
+| Demo video + HN launch | Month 1 | 100+ GitHub stars |
+| v1.0 release | Month 4 | 500+ stars, 10+ contributors |
+| MCP registry + marketplace | Month 5 | 1000+ installs |
+| v1.x incremental indexing | Month 7 | Daily active users metric established |
+| v2.0 team mode beta | Month 12 | 3+ teams in beta |
+| LSP integration (first language) | Month 15 | One language with LSP parity vs ast-grep |
+| v2.x document ingestion + GitHub hooks | Month 18 | PDF/markdown ingest working, 1+ webhook integration live |
+| IDE extension (VS Code) | Month 20 | Published on VS Code marketplace |
+
+---
+
+## Principles
+
+- **Local-first always works** — hosted mode is additive, never required
+- **Ship small, ship often** — weekly releases beat quarterly launches
+- **Community over features** — 10 engaged users matter more than 100 unused features
+- **Demo-driven development** — every feature should be showable in 30 seconds
+- **Prove with benchmarks** — claims backed by reproducible numbers
+- **Replace, don't layer** — one symbol extraction system at a time, not parallel stacks
+- **Open source** — Apache 2.0, community-driven development
+- **De-risk with proven tech** — Postgres over novel databases, SQLite stays the local default
+- **Minimize dependencies** — the single-binary, zero-dep story is a core differentiator


### PR DESCRIPTION
## Summary

- Remove hardcoded test counts (755/415) that go stale on every PR
- Fix MCP tool counts (28/30 → 32) across architecture, comparison, roadmap docs
- Fix enum counts (RelationshipType 23→24, NodeKind 12→13) in codemem-core README
- Rewrite CONTRIBUTING.md — was referencing 12 old crate names from pre-consolidation era, now matches current 6-crate structure
- Rewrite codemem-engine README — was describing only indexing, now covers all 15 engine modules
- Add session_id, batch insert, and transaction wrapping details to architecture.md
- Add missing MCP tools (get_node_memories, node_coverage) to architecture.md
- Update pipeline.md with multi-row INSERT and vector batch details
- Mark session continuity and persistence pipeline as done in roadmap
- Add roadmap.md (was untracked)

## Test plan

- [x] Verify all markdown renders correctly on GitHub
- [x] Grep for stale numbers (755, 415, "30 tools", "28 tools", "v0.8.0", "12 crates") — should find none

🤖 Generated with [Claude Code](https://claude.com/claude-code)