### PR TITLE
refactor: tier 1 quick wins — dead code, wiring, visibility, dedup

### DIFF
--- a/crates/codemem-core/src/config.rs
+++ b/crates/codemem-core/src/config.rs
@@ -198,8 +198,6 @@ impl Default for EmbeddingConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct StorageConfig {
-    /// Path to the database file.
-    pub db_path: String,
     /// SQLite cache size in MB.
     pub cache_size_mb: u32,
     /// SQLite busy timeout in seconds.
@@ -209,12 +207,6 @@ pub struct StorageConfig {
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
-            db_path: dirs::home_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join(".codemem")
-                .join("codemem.db")
-                .to_string_lossy()
-                .into_owned(),
             cache_size_mb: 64,
             busy_timeout_secs: 5,
         }

--- a/crates/codemem-core/src/tests/config_tests.rs
+++ b/crates/codemem-core/src/tests/config_tests.rs
@@ -274,8 +274,6 @@ fn save_rejects_invalid_config() {
 #[test]
 fn graph_config_defaults() {
     let config = GraphConfig::default();
-    assert_eq!(config.max_expansion_hops, 2);
-    assert!((config.bridge_similarity_threshold - 0.8).abs() < f64::EPSILON);
     assert!((config.contains_edge_weight - 0.1).abs() < f64::EPSILON);
     assert!((config.calls_edge_weight - 1.0).abs() < f64::EPSILON);
     assert!((config.imports_edge_weight - 0.5).abs() < f64::EPSILON);
@@ -286,11 +284,6 @@ fn graph_config_roundtrips_through_toml() {
     let config = GraphConfig::default();
     let toml_str = toml::to_string_pretty(&config).unwrap();
     let parsed: GraphConfig = toml::from_str(&toml_str).unwrap();
-    assert_eq!(parsed.max_expansion_hops, config.max_expansion_hops);
-    assert!(
-        (parsed.bridge_similarity_threshold - config.bridge_similarity_threshold).abs()
-            < f64::EPSILON
-    );
     assert!((parsed.calls_edge_weight - config.calls_edge_weight).abs() < f64::EPSILON);
 }
 

--- a/crates/codemem-core/src/types.rs
+++ b/crates/codemem-core/src/types.rs
@@ -414,8 +414,6 @@ pub enum DistanceMetric {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct GraphConfig {
-    pub max_expansion_hops: usize,
-    pub bridge_similarity_threshold: f64,
     /// Default edge weight for CONTAINS relationship (structural, low).
     pub contains_edge_weight: f64,
     /// Default edge weight for CALLS relationship (high signal).
@@ -427,8 +425,6 @@ pub struct GraphConfig {
 impl Default for GraphConfig {
     fn default() -> Self {
         Self {
-            max_expansion_hops: 2,
-            bridge_similarity_threshold: 0.8,
             contains_edge_weight: 0.1,
             calls_edge_weight: 1.0,
             imports_edge_weight: 0.5,

--- a/crates/codemem-embeddings/src/openai.rs
+++ b/crates/codemem-embeddings/src/openai.rs
@@ -33,6 +33,7 @@ impl OpenAIProvider {
     }
 
     /// Create with default model (text-embedding-3-small, 768 dims).
+    #[cfg(test)]
     pub fn with_api_key(api_key: &str) -> Self {
         Self::new(api_key, DEFAULT_MODEL, 768, None)
     }

--- a/crates/codemem-engine/src/bm25.rs
+++ b/crates/codemem-engine/src/bm25.rs
@@ -370,6 +370,7 @@ impl Bm25Index {
     }
 
     /// Build a BM25 index from a slice of (id, content) pairs.
+    #[cfg(test)]
     pub fn build(documents: &[(String, String)]) -> Self {
         let mut index = Self::new();
         for (id, content) in documents {

--- a/crates/codemem-engine/src/file_indexing.rs
+++ b/crates/codemem-engine/src/file_indexing.rs
@@ -1,9 +1,7 @@
 use crate::index::{self, IndexAndResolveResult, Indexer};
 use crate::patterns;
 use crate::CodememEngine;
-use codemem_core::{
-    CodememError, DetectedPattern, GraphBackend, MemoryNode, NodeKind, VectorBackend,
-};
+use codemem_core::{CodememError, DetectedPattern, GraphBackend, MemoryNode, VectorBackend};
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::Ordering;
@@ -245,39 +243,6 @@ impl CodememEngine {
 
         self.save_index();
         Ok(())
-    }
-
-    /// Compare files on disk vs file nodes in the graph and clean up stale entries.
-    /// Call this after indexing or on watcher delete events.
-    pub fn cleanup_deleted_files(&self, dir_path: &str) -> Result<usize, CodememError> {
-        let dir = Path::new(dir_path);
-        if !dir.is_dir() {
-            return Ok(0);
-        }
-
-        // Collect file: nodes from the graph
-        let graph = self.lock_graph()?;
-        let file_nodes: Vec<String> = graph
-            .get_all_nodes()
-            .into_iter()
-            .filter(|n| n.kind == NodeKind::File && n.label.starts_with(dir_path))
-            .map(|n| n.label.clone())
-            .collect();
-        drop(graph);
-
-        let mut cleaned = 0usize;
-        for file_path in &file_nodes {
-            if !Path::new(file_path).exists() {
-                self.cleanup_file_nodes(file_path)?;
-                cleaned += 1;
-            }
-        }
-
-        if cleaned > 0 {
-            self.lock_graph()?.recompute_centrality();
-        }
-
-        Ok(cleaned)
     }
 
     // ── A4: Combined Index + Enrich Pipeline ────────────────────────────

--- a/crates/codemem-engine/src/hooks/extractors.rs
+++ b/crates/codemem-engine/src/hooks/extractors.rs
@@ -3,6 +3,7 @@
 use codemem_core::{CodememError, GraphNode, MemoryType, NodeKind};
 use std::collections::HashMap;
 
+use super::diff::compute_diff;
 use super::{ExtractedMemory, HookPayload};
 
 /// Relativize an absolute file path against the hook's cwd.
@@ -180,20 +181,37 @@ pub(super) fn extract_edit(payload: &HookPayload) -> Result<Option<ExtractedMemo
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
+    // Compute a semantic diff summary from the old/new strings.
+    let diff_summary = compute_diff(file_path, old_string, new_string);
+
     let content = format!(
-        "Edit: {}\nChanged:\n  - {}\n  + {}",
+        "Edit: {}\nSemantic summary: {}\nChanged:\n  - {}\n  + {}",
         file_path,
+        diff_summary.semantic_summary,
         truncate(old_string, 500),
         truncate(new_string, 500)
     );
 
-    Ok(Some(build_file_extraction(
-        payload,
-        file_path,
-        content,
-        MemoryType::Decision,
-        "Edit",
-    )))
+    let mut extraction =
+        build_file_extraction(payload, file_path, content, MemoryType::Decision, "Edit");
+    extraction.metadata.insert(
+        "semantic_summary".to_string(),
+        serde_json::Value::String(diff_summary.semantic_summary),
+    );
+    extraction.metadata.insert(
+        "lines_added".to_string(),
+        serde_json::json!(diff_summary.lines_added),
+    );
+    extraction.metadata.insert(
+        "lines_removed".to_string(),
+        serde_json::json!(diff_summary.lines_removed),
+    );
+    extraction.metadata.insert(
+        "change_type".to_string(),
+        serde_json::Value::String(diff_summary.change_type.to_string()),
+    );
+
+    Ok(Some(extraction))
 }
 
 /// Extract memory from a Write tool use.

--- a/crates/codemem-engine/src/index/engine/mod.rs
+++ b/crates/codemem-engine/src/index/engine/mod.rs
@@ -22,8 +22,10 @@ use std::sync::LazyLock;
 pub type SgNode<'r> = Node<'r, StrDoc<SupportLang>>;
 
 /// One-time deserialized language rules, shared across all AstGrepEngine instances.
-static LOADED_RULES: LazyLock<Vec<LanguageRules>> =
-    LazyLock::new(crate::index::rule_loader::load_all_rules);
+static LOADED_RULES: LazyLock<Vec<LanguageRules>> = LazyLock::new(|| {
+    crate::index::rule_loader::load_all_rules()
+        .expect("embedded YAML rule files must deserialize successfully")
+});
 
 /// The unified extraction engine.
 pub struct AstGrepEngine {

--- a/crates/codemem-engine/src/index/rule_loader.rs
+++ b/crates/codemem-engine/src/index/rule_loader.rs
@@ -1,6 +1,7 @@
 //! Compile-time YAML rule embedding and deserialization for per-language extraction rules.
 
 use ast_grep_language::SupportLang;
+use codemem_core::CodememError;
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -278,26 +279,25 @@ static LANGUAGE_RULES: &[EmbeddedRules] = &[
 
 /// Load and deserialize all language rules.
 ///
-/// # Panics
-///
-/// Panics if any embedded YAML rule file fails to deserialize. This is intentional:
-/// these files are compiled into the binary, so a parse failure indicates a build-time
-/// error that must be fixed before shipping.
-pub fn load_all_rules() -> Vec<LanguageRules> {
+/// Returns an error if any embedded YAML rule file fails to deserialize.
+pub fn load_all_rules() -> Result<Vec<LanguageRules>, CodememError> {
     LANGUAGE_RULES
         .iter()
         .map(|embedded| {
-            let sym_file: SymbolRulesFile = serde_yaml::from_str(embedded.symbols_yaml)
-                .unwrap_or_else(|e| {
-                    panic!("Failed to parse symbols.yml for {}: {}", embedded.name, e)
-                });
+            let sym_file: SymbolRulesFile =
+                serde_yaml::from_str(embedded.symbols_yaml).map_err(|e| {
+                    CodememError::Config(format!(
+                        "Failed to parse symbols.yml for {}: {}",
+                        embedded.name, e
+                    ))
+                })?;
             let ref_file: ReferenceRulesFile = serde_yaml::from_str(embedded.references_yaml)
-                .unwrap_or_else(|e| {
-                    panic!(
+                .map_err(|e| {
+                    CodememError::Config(format!(
                         "Failed to parse references.yml for {}: {}",
                         embedded.name, e
-                    )
-                });
+                    ))
+                })?;
 
             let mut rules = LanguageRules {
                 name: embedded.name,
@@ -318,7 +318,7 @@ pub fn load_all_rules() -> Vec<LanguageRules> {
                 reference_unwrap_set: std::collections::HashSet::new(),
             };
             rules.build_indexes();
-            rules
+            Ok(rules)
         })
         .collect()
 }

--- a/crates/codemem-engine/src/search.rs
+++ b/crates/codemem-engine/src/search.rs
@@ -145,6 +145,7 @@ impl CodememEngine {
     ///
     /// Returns an estimate in bytes. Actual usage may be higher due to HashMap overhead,
     /// string heap allocations, and payload contents.
+    #[cfg(test)]
     pub fn graph_memory_estimate(&self) -> usize {
         let (node_count, edge_count) = match self.lock_graph() {
             Ok(g) => (g.node_count(), g.edge_count()),

--- a/crates/codemem-engine/src/tests/persistence_tests.rs
+++ b/crates/codemem-engine/src/tests/persistence_tests.rs
@@ -119,7 +119,6 @@ fn edge_weight_for_custom_config() {
         calls_edge_weight: 0.9,
         imports_edge_weight: 0.3,
         contains_edge_weight: 0.2,
-        ..Default::default()
     };
     assert_eq!(edge_weight_for(&RelationshipType::Calls, &config), 0.9);
     assert_eq!(edge_weight_for(&RelationshipType::Imports, &config), 0.3);

--- a/crates/codemem-storage/src/backend.rs
+++ b/crates/codemem-storage/src/backend.rs
@@ -111,24 +111,7 @@ impl StorageBackend for Storage {
             .collect();
 
         let rows = stmt
-            .query_map(params.as_slice(), |row| {
-                Ok(MemoryRow {
-                    id: row.get(0)?,
-                    content: row.get(1)?,
-                    memory_type: row.get(2)?,
-                    importance: row.get(3)?,
-                    confidence: row.get(4)?,
-                    access_count: row.get(5)?,
-                    content_hash: row.get(6)?,
-                    tags: row.get(7)?,
-                    metadata: row.get(8)?,
-                    namespace: row.get(9)?,
-                    session_id: row.get(10)?,
-                    created_at: row.get(11)?,
-                    updated_at: row.get(12)?,
-                    last_accessed_at: row.get(13)?,
-                })
-            })
+            .query_map(params.as_slice(), MemoryRow::from_row)
             .map_err(|e| CodememError::Storage(e.to_string()))?;
 
         let mut memories = Vec::new();
@@ -708,24 +691,7 @@ impl StorageBackend for Storage {
             .map_err(|e| CodememError::Storage(e.to_string()))?;
 
         let rows = stmt
-            .query_map(refs.as_slice(), |row| {
-                Ok(MemoryRow {
-                    id: row.get(0)?,
-                    content: row.get(1)?,
-                    memory_type: row.get(2)?,
-                    importance: row.get(3)?,
-                    confidence: row.get(4)?,
-                    access_count: row.get(5)?,
-                    content_hash: row.get(6)?,
-                    tags: row.get(7)?,
-                    metadata: row.get(8)?,
-                    namespace: row.get(9)?,
-                    session_id: row.get(10)?,
-                    created_at: row.get(11)?,
-                    updated_at: row.get(12)?,
-                    last_accessed_at: row.get(13)?,
-                })
-            })
+            .query_map(refs.as_slice(), MemoryRow::from_row)
             .map_err(|e| CodememError::Storage(e.to_string()))?;
 
         let mut result = Vec::new();

--- a/crates/codemem-storage/src/graph/algorithms.rs
+++ b/crates/codemem-storage/src/graph/algorithms.rs
@@ -100,6 +100,7 @@ impl GraphEngine {
     /// Nodes not in seed_weights get zero teleport probability.
     ///
     /// Used for blast-radius analysis and HippoRAG-2-style retrieval.
+    #[cfg(test)]
     pub fn personalized_pagerank(
         &self,
         seed_weights: &HashMap<String, f64>,
@@ -439,6 +440,7 @@ impl GraphEngine {
     ///
     /// Returns groups of node IDs. Each group is a strongly connected component
     /// where every node can reach every other node via directed edges.
+    #[cfg(test)]
     pub fn strongly_connected_components(&self) -> Vec<Vec<String>> {
         let sccs = petgraph::algo::tarjan_scc(&self.graph);
 

--- a/crates/codemem-storage/src/graph/mod.rs
+++ b/crates/codemem-storage/src/graph/mod.rs
@@ -417,6 +417,7 @@ impl GraphEngine {
 
     /// Get the maximum degree (in + out) across all nodes in the graph.
     /// Returns 1.0 if the graph has fewer than 2 nodes to avoid division by zero.
+    #[cfg(test)]
     pub fn max_degree(&self) -> f64 {
         if self.nodes.len() <= 1 {
             return 1.0;

--- a/crates/codemem-storage/src/lib.rs
+++ b/crates/codemem-storage/src/lib.rs
@@ -161,6 +161,25 @@ pub(crate) struct MemoryRow {
 }
 
 impl MemoryRow {
+    pub(crate) fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Self {
+            id: row.get(0)?,
+            content: row.get(1)?,
+            memory_type: row.get(2)?,
+            importance: row.get(3)?,
+            confidence: row.get(4)?,
+            access_count: row.get(5)?,
+            content_hash: row.get(6)?,
+            tags: row.get(7)?,
+            metadata: row.get(8)?,
+            namespace: row.get(9)?,
+            session_id: row.get(10)?,
+            created_at: row.get(11)?,
+            updated_at: row.get(12)?,
+            last_accessed_at: row.get(13)?,
+        })
+    }
+
     pub(crate) fn into_memory_node(self) -> Result<MemoryNode, CodememError> {
         let memory_type: MemoryType = self.memory_type.parse()?;
         let tags: Vec<String> = serde_json::from_str(&self.tags).unwrap_or_else(|e| {

--- a/crates/codemem-storage/src/memory.rs
+++ b/crates/codemem-storage/src/memory.rs
@@ -142,24 +142,7 @@ impl Storage {
             .query_row(
                 "SELECT id, content, memory_type, importance, confidence, access_count, content_hash, tags, metadata, namespace, session_id, created_at, updated_at, last_accessed_at FROM memories WHERE id = ?1",
                 params![id],
-                |row| {
-                    Ok(MemoryRow {
-                        id: row.get(0)?,
-                        content: row.get(1)?,
-                        memory_type: row.get(2)?,
-                        importance: row.get(3)?,
-                        confidence: row.get(4)?,
-                        access_count: row.get(5)?,
-                        content_hash: row.get(6)?,
-                        tags: row.get(7)?,
-                        metadata: row.get(8)?,
-                        namespace: row.get(9)?,
-                        session_id: row.get(10)?,
-                        created_at: row.get(11)?,
-                        updated_at: row.get(12)?,
-                        last_accessed_at: row.get(13)?,
-                    })
-                },
+                MemoryRow::from_row,
             )
             .optional()
             .map_err(|e| CodememError::Storage(e.to_string()))?;
@@ -179,24 +162,7 @@ impl Storage {
             .query_row(
                 "SELECT id, content, memory_type, importance, confidence, access_count, content_hash, tags, metadata, namespace, session_id, created_at, updated_at, last_accessed_at FROM memories WHERE id = ?1",
                 params![id],
-                |row| {
-                    Ok(MemoryRow {
-                        id: row.get(0)?,
-                        content: row.get(1)?,
-                        memory_type: row.get(2)?,
-                        importance: row.get(3)?,
-                        confidence: row.get(4)?,
-                        access_count: row.get(5)?,
-                        content_hash: row.get(6)?,
-                        tags: row.get(7)?,
-                        metadata: row.get(8)?,
-                        namespace: row.get(9)?,
-                        session_id: row.get(10)?,
-                        created_at: row.get(11)?,
-                        updated_at: row.get(12)?,
-                        last_accessed_at: row.get(13)?,
-                    })
-                },
+                MemoryRow::from_row,
             )
             .optional()
             .map_err(|e| CodememError::Storage(e.to_string()))?;

--- a/crates/codemem/src/cli/commands_consolidation.rs
+++ b/crates/codemem/src/cli/commands_consolidation.rs
@@ -3,7 +3,7 @@
 use codemem_engine::CodememEngine;
 
 /// All valid consolidation cycle types.
-pub(crate) const VALID_CYCLES: &[&str] = &["decay", "creative", "cluster", "forget"];
+pub(crate) const VALID_CYCLES: &[&str] = &["decay", "creative", "cluster", "forget", "summarize"];
 
 /// Returns `true` if the given cycle name is a known consolidation cycle.
 pub(crate) fn is_valid_cycle(cycle: &str) -> bool {
@@ -29,6 +29,7 @@ pub(crate) fn cmd_consolidate(cycle: &str) -> anyhow::Result<()> {
         "creative" => engine.consolidate_creative()?,
         "cluster" => engine.consolidate_cluster(None)?,
         "forget" => engine.consolidate_forget(None, None, None)?,
+        "summarize" => engine.consolidate_summarize(None)?,
         _ => unreachable!("is_valid_cycle check above"),
     };
 

--- a/crates/codemem/src/cli/tests/commands_consolidation_tests.rs
+++ b/crates/codemem/src/cli/tests/commands_consolidation_tests.rs
@@ -3,8 +3,8 @@ use super::*;
 // ── VALID_CYCLES constant ─────────────────────────────────────────────────
 
 #[test]
-fn valid_cycles_contains_four_entries() {
-    assert_eq!(VALID_CYCLES.len(), 4);
+fn valid_cycles_contains_five_entries() {
+    assert_eq!(VALID_CYCLES.len(), 5);
 }
 
 #[test]
@@ -27,18 +27,22 @@ fn valid_cycles_contains_forget() {
     assert!(VALID_CYCLES.contains(&"forget"));
 }
 
+#[test]
+fn valid_cycles_contains_summarize() {
+    assert!(VALID_CYCLES.contains(&"summarize"));
+}
+
 // ── is_valid_cycle tests ──────────────────────────────────────────────────
 
 #[test]
 fn is_valid_cycle_accepts_known_cycles() {
-    for name in &["decay", "creative", "cluster", "forget"] {
+    for name in &["decay", "creative", "cluster", "forget", "summarize"] {
         assert!(is_valid_cycle(name), "{name} should be valid");
     }
 }
 
 #[test]
 fn is_valid_cycle_rejects_unknown() {
-    assert!(!is_valid_cycle("summarize"));
     assert!(!is_valid_cycle("rem"));
     assert!(!is_valid_cycle(""));
     assert!(!is_valid_cycle("DECAY"));

--- a/crates/codemem/src/mcp/mod.rs
+++ b/crates/codemem/src/mcp/mod.rs
@@ -1,6 +1,6 @@
 //! codemem-mcp: MCP server for Codemem (JSON-RPC 2.0 over stdio).
 //!
-//! Implements 30 tools:
+//! Implements 32 tools:
 //! store_memory, recall, delete_memory, associate_memories, refine_memory,
 //! split_memory, merge_memories, graph_traverse, summary_tree,
 //! codemem_status, index_codebase, search_code, get_symbol_info,

--- a/crates/codemem/src/mcp/tests/definitions_tests.rs
+++ b/crates/codemem/src/mcp/tests/definitions_tests.rs
@@ -7,8 +7,8 @@ fn tool_definitions_returns_expected_count() {
     // The dispatch table in mod.rs has 32 tool entries (including the unknown fallback).
     // definitions.rs should define all of them.
     assert!(
-        defs.len() >= 30,
-        "Expected at least 30 tool definitions, got {}",
+        defs.len() >= 32,
+        "Expected at least 32 tool definitions, got {}",
         defs.len()
     );
 }
@@ -232,8 +232,8 @@ fn tools_list_rpc_returns_definitions() {
     let result = resp.result.unwrap();
     let tools = result["tools"].as_array().unwrap();
     assert!(
-        tools.len() >= 30,
-        "tools/list should return at least 30 tools, got {}",
+        tools.len() >= 32,
+        "tools/list should return at least 32 tools, got {}",
         tools.len()
     );
 }

--- a/crates/codemem/src/mcp/tools_consolidation.rs
+++ b/crates/codemem/src/mcp/tools_consolidation.rs
@@ -131,6 +131,36 @@ impl McpServer {
                     }
                 }
 
+                // Run cluster
+                match self.engine.consolidate_cluster(None) {
+                    Ok(r) => {
+                        results["cluster"] = json!({"cycle": r.cycle, "affected": r.affected});
+                    }
+                    Err(e) => {
+                        results["cluster"] = json!({"error": format!("{e}")});
+                    }
+                }
+
+                // Run forget with safe defaults
+                match self.engine.consolidate_forget(None, None, None) {
+                    Ok(r) => {
+                        results["forget"] = json!({"cycle": r.cycle, "deleted": r.affected});
+                    }
+                    Err(e) => {
+                        results["forget"] = json!({"error": format!("{e}")});
+                    }
+                }
+
+                // Run summarize
+                match self.engine.consolidate_summarize(None) {
+                    Ok(r) => {
+                        results["summarize"] = json!({"cycle": r.cycle, "affected": r.affected});
+                    }
+                    Err(e) => {
+                        results["summarize"] = json!({"error": format!("{e}")});
+                    }
+                }
+
                 // Include status
                 let mut status_json = json!({});
                 for entry in &status {

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -108,7 +108,7 @@ A comprehensive comparison of Codemem against other memory and context tools in 
 
 **When to choose Cognee**: Processing diverse data sources (PDFs, docs, web), need LLM-powered knowledge extraction, building knowledge graphs at enterprise scale, need multilingual support.
 
-**When to choose Codemem**: Code-focused memory, offline operation, single-binary deployment, graph algorithms with cached centrality.
+**When to choose Codemem**: Code-focused memory with structural indexing (14 languages), offline operation, single-binary zero-dependency deployment, graph algorithms with cached centrality.
 
 ### Codemem vs claude-context
 
@@ -152,7 +152,7 @@ A comprehensive comparison of Codemem against other memory and context tools in 
 | **Web viewer** | PCA visualization dashboard | React UI with SSE, infinite scroll, Endless Mode (beta) |
 | **Privacy** | Namespace scoping | `<private>` tag exclusion |
 
-**When to choose claude-mem**: Want zero-config AI compression, prefer a polished web viewer, already use Bun/Node.js, want the Claude Code plugin marketplace experience.
+**When to choose claude-mem**: Want zero-config AI compression with always-on Claude Agent SDK, already use Bun/Node.js, want the Claude Code plugin marketplace experience.
 
 **When to choose Codemem**: Need code-aware structural intelligence, graph-based reasoning, single binary with no runtime deps, offline-first operation, code-aware hybrid scoring, consolidation cycles, self-editing memory.
 
@@ -172,6 +172,10 @@ A comprehensive comparison of Codemem against other memory and context tools in 
 | **Dependencies** | None | Python + Docker + FalkorDB + Qdrant |
 
 Codemem was directly inspired by AutoMem's research. The key difference is packaging: Codemem embeds the same graph-vector hybrid approach into a single Rust binary optimized for AI coding assistants.
+
+**When to choose AutoMem**: Research benchmark reproduction, already running FalkorDB + Qdrant, want the original HippoRAG implementation.
+
+**When to choose Codemem**: Code-specific memory, single binary with no Docker/DB dependencies, offline operation, 14-language structural indexing.
 
 ### Codemem vs OpenMemory MCP
 
@@ -212,13 +216,13 @@ Codemem was directly inspired by AutoMem's research. The key difference is packa
 | Persistent memory for AI coding with zero setup | **Codemem** |
 | Single binary, offline, no runtime deps | **Codemem** |
 | Code-aware structural indexing + CST chunking + graph reasoning | **Codemem** |
-| Benchmark-leading accuracy across multiple benchmarks | **Supermemory** |
+| Multi-modal memory (docs, images, video) + cloud-hosted API | **Supermemory** |
 | Zero-config session memory with AI compression | **claude-mem** |
 | General-purpose AI memory with cloud scale and multi-tenancy | **Mem0** |
 | Temporal knowledge graph with event timelines | **Zep/Graphiti** |
 | Autonomous self-editing agent memory + deployment platform | **Letta** |
 | LLM-powered knowledge extraction from diverse documents | **Cognee** |
-| Code search with AST splitting + managed vector DB | **claude-context** |
+| Code search only (no persistent memory) + managed Zilliz Cloud | **claude-context** |
 | Multi-sector memory with adaptive decay + SaaS connectors | **OpenMemory MCP** |
 | Memory OS with multi-modal + parameter-level memory | **MemOS** |
 


### PR DESCRIPTION
## Summary

10 quick-win cleanups from code review:

- **Dead code**: Delete `cleanup_deleted_files()` (zero callers), unused `GraphConfig` fields, unused `StorageConfig.db_path`
- **Wiring**: `compute_diff()` now called in edit extractor with old/new strings; "summarize" added to CLI `VALID_CYCLES`; MCP auto mode runs all 5 consolidation cycles
- **Safety**: Replace `panic!()` in `rule_loader.rs` with `Result` return
- **Visibility**: 6 test-only pub functions narrowed with `#[cfg(test)]`
- **Dedup**: Extract `MemoryRow::from_row()` eliminating 4 copy-paste blocks
- **Docs**: Fix stale "30 tools" → 32; fix comparison.md recommendations

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 1130 passed, 0 failed
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)