### PR TITLE
refactor: tier 2 quick wins — constructors, dedup helpers, storage ergonomics

### DIFF
--- a/crates/codemem-bench/benches/storage.rs
+++ b/crates/codemem-bench/benches/storage.rs
@@ -1,30 +1,14 @@
-use codemem_core::{MemoryNode, MemoryType};
+use codemem_core::MemoryNode;
 use codemem_storage::Storage;
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::collections::HashMap;
 
 /// Create a test memory with a unique content hash derived from the index.
 fn make_memory(i: usize) -> MemoryNode {
-    let now = chrono::Utc::now();
-    let content = format!(
+    let mut m = MemoryNode::test_default(&format!(
         "Benchmark memory entry number {i}: testing storage CRUD performance with varied content"
-    );
-    MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.clone(),
-        memory_type: MemoryType::Context,
-        importance: 0.5,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: Storage::content_hash(&content),
-        tags: vec!["bench".to_string(), format!("group-{}", i % 10)],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    ));
+    m.tags = vec!["bench".to_string(), format!("group-{}", i % 10)];
+    m
 }
 
 /// Benchmark inserting memories into an in-memory SQLite database.

--- a/crates/codemem-core/src/lib.rs
+++ b/crates/codemem-core/src/lib.rs
@@ -5,6 +5,10 @@ pub mod error;
 pub mod metrics;
 pub mod traits;
 pub mod types;
+pub mod utils;
+
+// ── utils ───────────────────────────────────────────────────────────────────
+pub use utils::truncate;
 
 // ── config ──────────────────────────────────────────────────────────────────
 pub use config::{ChunkingConfig, CodememConfig, EmbeddingConfig, EnrichmentConfig, StorageConfig};

--- a/crates/codemem-core/src/tests/types_tests.rs
+++ b/crates/codemem-core/src/tests/types_tests.rs
@@ -240,33 +240,23 @@ fn detected_pattern_serialization() {
 // ── MemoryNode JSON round-trip ──────────────────────────────────────────────
 
 fn make_memory_node() -> MemoryNode {
-    let now = Utc::now();
-    let mut metadata = HashMap::new();
-    metadata.insert(
+    let mut m = MemoryNode::test_default("Use early returns for error handling");
+    m.id = "mem-abc-123".to_string();
+    m.memory_type = MemoryType::Decision;
+    m.importance = 0.8;
+    m.confidence = 0.95;
+    m.access_count = 3;
+    m.tags = vec!["rust".to_string(), "error-handling".to_string()];
+    m.metadata.insert(
         "source".to_string(),
         serde_json::Value::String("test".to_string()),
     );
-    metadata.insert(
+    m.metadata.insert(
         "count".to_string(),
         serde_json::Value::Number(serde_json::Number::from(42)),
     );
-
-    MemoryNode {
-        id: "mem-abc-123".to_string(),
-        content: "Use early returns for error handling".to_string(),
-        memory_type: MemoryType::Decision,
-        importance: 0.8,
-        confidence: 0.95,
-        access_count: 3,
-        content_hash: content_hash("Use early returns for error handling"),
-        tags: vec!["rust".to_string(), "error-handling".to_string()],
-        metadata,
-        namespace: Some("my-project".to_string()),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    m.namespace = Some("my-project".to_string());
+    m
 }
 
 #[test]
@@ -292,23 +282,10 @@ fn memory_node_json_roundtrip() {
 
 #[test]
 fn memory_node_empty_content() {
-    let now = Utc::now();
-    let node = MemoryNode {
-        id: "mem-empty".to_string(),
-        content: String::new(),
-        memory_type: MemoryType::Context,
-        importance: 0.0,
-        confidence: 0.0,
-        access_count: 0,
-        content_hash: content_hash(""),
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut node = MemoryNode::test_default("");
+    node.id = "mem-empty".to_string();
+    node.importance = 0.0;
+    node.confidence = 0.0;
     let json = serde_json::to_string(&node).unwrap();
     let parsed: MemoryNode = serde_json::from_str(&json).unwrap();
     assert_eq!(parsed.content, "");
@@ -319,25 +296,14 @@ fn memory_node_empty_content() {
 
 #[test]
 fn memory_node_unicode_content() {
-    let now = Utc::now();
     let unicode_content =
         "Unicode: \u{1F600} \u{1F680} \u{4E16}\u{754C} caf\u{E9} \u{00FC}ber \u{2603}\u{FE0F}";
-    let node = MemoryNode {
-        id: "mem-unicode".to_string(),
-        content: unicode_content.to_string(),
-        memory_type: MemoryType::Insight,
-        importance: 0.5,
-        confidence: 0.5,
-        access_count: 1,
-        content_hash: content_hash(unicode_content),
-        tags: vec!["\u{1F3F7}\u{FE0F}tag".to_string()],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut node = MemoryNode::test_default(unicode_content);
+    node.id = "mem-unicode".to_string();
+    node.memory_type = MemoryType::Insight;
+    node.confidence = 0.5;
+    node.access_count = 1;
+    node.tags = vec!["\u{1F3F7}\u{FE0F}tag".to_string()];
     let json = serde_json::to_string(&node).unwrap();
     let parsed: MemoryNode = serde_json::from_str(&json).unwrap();
     assert_eq!(parsed.content, unicode_content);
@@ -346,23 +312,11 @@ fn memory_node_unicode_content() {
 
 #[test]
 fn memory_node_empty_tags() {
-    let now = Utc::now();
-    let node = MemoryNode {
-        id: "mem-no-tags".to_string(),
-        content: "no tags here".to_string(),
-        memory_type: MemoryType::Pattern,
-        importance: 0.3,
-        confidence: 0.7,
-        access_count: 0,
-        content_hash: content_hash("no tags here"),
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut node = MemoryNode::test_default("no tags here");
+    node.id = "mem-no-tags".to_string();
+    node.memory_type = MemoryType::Pattern;
+    node.importance = 0.3;
+    node.confidence = 0.7;
     let json = serde_json::to_string(&node).unwrap();
     let parsed: MemoryNode = serde_json::from_str(&json).unwrap();
     assert!(parsed.tags.is_empty());

--- a/crates/codemem-core/src/types.rs
+++ b/crates/codemem-core/src/types.rs
@@ -273,6 +273,38 @@ pub struct MemoryNode {
     pub last_accessed_at: DateTime<Utc>,
 }
 
+impl MemoryNode {
+    /// Create a test/example memory with minimal fields.
+    /// Uses `MemoryType::Context` and default values for importance (0.5),
+    /// confidence (1.0), empty tags, and empty metadata.
+    pub fn test_default(content: &str) -> Self {
+        Self::new(content.to_string(), MemoryType::Context)
+    }
+
+    /// Create a new MemoryNode with sensible defaults.
+    /// Auto-generates id, content_hash, and timestamps.
+    pub fn new(content: impl Into<String>, memory_type: MemoryType) -> Self {
+        let content = content.into();
+        let now = chrono::Utc::now();
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            content_hash: content_hash(&content),
+            content,
+            memory_type,
+            importance: 0.5,
+            confidence: 1.0,
+            access_count: 0,
+            tags: Vec::new(),
+            metadata: HashMap::new(),
+            namespace: None,
+            session_id: None,
+            created_at: now,
+            updated_at: now,
+            last_accessed_at: now,
+        }
+    }
+}
+
 /// A graph edge connecting two nodes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Edge {

--- a/crates/codemem-core/src/utils.rs
+++ b/crates/codemem-core/src/utils.rs
@@ -1,0 +1,60 @@
+/// Truncate a string to `max` bytes, appending "..." if truncated.
+/// Handles multi-byte UTF-8 safely by finding the nearest char boundary.
+pub fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_string_unchanged() {
+        assert_eq!(truncate("hi", 10), "hi");
+    }
+
+    #[test]
+    fn exact_length_unchanged() {
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn long_string_truncated_with_ellipsis() {
+        assert_eq!(truncate("hello world", 5), "hello...");
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(truncate("", 5), "");
+    }
+
+    #[test]
+    fn zero_max() {
+        assert_eq!(truncate("abc", 0), "...");
+    }
+
+    #[test]
+    fn multibyte_utf8_safe() {
+        let result = truncate("héllo", 2);
+        assert!(result.ends_with("..."));
+        // 'h' is 1 byte, 'é' is 2 bytes, so at max=2 we can fit "hé" (3 bytes > 2),
+        // boundary backs up to 1, giving "h..."
+        assert_eq!(result, "h...");
+    }
+
+    #[test]
+    fn multibyte_cjk() {
+        let result = truncate("日本語テスト", 4);
+        // '日' is 3 bytes, next char starts at byte 3, byte 4 is mid-char, backs to 3
+        assert!(result.ends_with("..."));
+        assert_eq!(result, "日...");
+    }
+}

--- a/crates/codemem-engine/src/analysis.rs
+++ b/crates/codemem-engine/src/analysis.rs
@@ -331,8 +331,6 @@ impl CodememEngine {
                 .has_auto_insight(session_id, &dedup_tag)
                 .unwrap_or(true);
             if !already_exists && pattern.confidence > 0.3 {
-                let now = chrono::Utc::now();
-                let hash = codemem_storage::Storage::content_hash(&pattern.description);
                 let mut metadata = HashMap::new();
                 metadata.insert("session_id".to_string(), json!(session_id));
                 metadata.insert("auto_insight_tag".to_string(), json!(dedup_tag));
@@ -342,25 +340,18 @@ impl CodememEngine {
                     json!(pattern.pattern_type.to_string()),
                 );
 
-                let mem = codemem_core::MemoryNode {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    content: format!("Session pattern: {}", pattern.description),
-                    memory_type: MemoryType::Insight,
-                    importance: 0.6,
-                    confidence: pattern.confidence,
-                    access_count: 0,
-                    content_hash: hash,
-                    tags: vec![
-                        "session-checkpoint".to_string(),
-                        format!("pattern:{}", pattern.pattern_type),
-                    ],
-                    metadata,
-                    namespace: namespace.map(|s| s.to_string()),
-                    session_id: None,
-                    created_at: now,
-                    updated_at: now,
-                    last_accessed_at: now,
-                };
+                let mut mem = codemem_core::MemoryNode::new(
+                    format!("Session pattern: {}", pattern.description),
+                    MemoryType::Insight,
+                );
+                mem.importance = 0.6;
+                mem.confidence = pattern.confidence;
+                mem.tags = vec![
+                    "session-checkpoint".to_string(),
+                    format!("pattern:{}", pattern.pattern_type),
+                ];
+                mem.metadata = metadata;
+                mem.namespace = namespace.map(|s| s.to_string());
                 if self.storage.insert_memory(&mem).is_ok() {
                     stored_patterns += 1;
                 }
@@ -407,8 +398,6 @@ impl CodememEngine {
             memory_count,
             session_patterns.len(),
         );
-        let hash = codemem_storage::Storage::content_hash(&checkpoint_content);
-
         let mut checkpoint_metadata = HashMap::new();
         checkpoint_metadata.insert("checkpoint_type".to_string(), json!("manual"));
         checkpoint_metadata.insert("session_id".to_string(), json!(session_id));
@@ -426,25 +415,15 @@ impl CodememEngine {
             checkpoint_metadata.insert("hot_directories".to_string(), json!(dirs));
         }
 
-        let checkpoint_mem = codemem_core::MemoryNode {
-            id: uuid::Uuid::new_v4().to_string(),
-            content: checkpoint_content,
-            memory_type: MemoryType::Context,
-            importance: 0.5,
-            confidence: 1.0,
-            access_count: 0,
-            content_hash: hash,
-            tags: vec![
-                "session-checkpoint".to_string(),
-                format!("session:{session_id}"),
-            ],
-            metadata: checkpoint_metadata,
-            namespace: namespace.map(|s| s.to_string()),
-            session_id: Some(session_id.to_string()),
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut checkpoint_mem =
+            codemem_core::MemoryNode::new(checkpoint_content, MemoryType::Context);
+        checkpoint_mem.tags = vec![
+            "session-checkpoint".to_string(),
+            format!("session:{session_id}"),
+        ];
+        checkpoint_mem.metadata = checkpoint_metadata;
+        checkpoint_mem.namespace = namespace.map(|s| s.to_string());
+        checkpoint_mem.session_id = Some(session_id.to_string());
         // Best-effort persist; don't fail the checkpoint if this errors
         let _ = self.persist_memory(&checkpoint_mem);
 

--- a/crates/codemem-engine/src/consolidation/summarize.rs
+++ b/crates/codemem-engine/src/consolidation/summarize.rs
@@ -90,26 +90,10 @@ impl CodememEngine {
             all_tags.sort();
             all_tags.dedup();
 
-            let now = chrono::Utc::now();
-            let new_id = uuid::Uuid::new_v4().to_string();
-            let hash = codemem_storage::Storage::content_hash(&summary);
-
-            let mem = MemoryNode {
-                id: new_id.clone(),
-                content: summary,
-                memory_type: MemoryType::Insight,
-                importance: 0.7,
-                confidence: 1.0,
-                access_count: 0,
-                content_hash: hash,
-                tags: all_tags,
-                metadata: HashMap::new(),
-                namespace: None,
-                session_id: None,
-                created_at: now,
-                updated_at: now,
-                last_accessed_at: now,
-            };
+            let mut mem = MemoryNode::new(summary, MemoryType::Insight);
+            let new_id = mem.id.clone();
+            mem.importance = 0.7;
+            mem.tags = all_tags;
 
             // M4: Use persist_memory_no_save to skip per-memory index save,
             // then call save_index() once after the entire loop.
@@ -118,6 +102,7 @@ impl CodememEngine {
                 continue;
             }
 
+            let now = chrono::Utc::now();
             if let Ok(mut graph) = self.lock_graph() {
                 for sid in &source_ids {
                     let edge = Edge {

--- a/crates/codemem-engine/src/enrichment/mod.rs
+++ b/crates/codemem-engine/src/enrichment/mod.rs
@@ -99,26 +99,16 @@ impl CodememEngine {
         }
 
         // ── Phase 2: Core persist via persist_memory_no_save ─────────────
-        let hash = codemem_storage::Storage::content_hash(content);
-        let memory = MemoryNode {
-            id: id.clone(),
-            content: content.to_string(),
-            memory_type: MemoryType::Insight,
-            importance: importance.clamp(0.0, 1.0),
-            confidence: self.config.enrichment.insight_confidence,
-            access_count: 0,
-            content_hash: hash,
-            tags: all_tags,
-            metadata: HashMap::from([
-                ("track".into(), json!(track)),
-                ("generated_by".into(), json!("enrichment_pipeline")),
-            ]),
-            namespace: namespace.map(String::from),
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::new(content, MemoryType::Insight);
+        memory.id = id.clone();
+        memory.importance = importance.clamp(0.0, 1.0);
+        memory.confidence = self.config.enrichment.insight_confidence;
+        memory.tags = all_tags;
+        memory.metadata = HashMap::from([
+            ("track".into(), json!(track)),
+            ("generated_by".into(), json!("enrichment_pipeline")),
+        ]);
+        memory.namespace = namespace.map(String::from);
 
         if self.persist_memory_no_save(&memory).is_err() {
             return None; // duplicate or error -- skip silently
@@ -247,33 +237,22 @@ impl CodememEngine {
         namespace: Option<&str>,
         links: &[String],
     ) -> Option<String> {
-        let hash = codemem_storage::Storage::content_hash(content);
-        let now = chrono::Utc::now();
         let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now();
         let tags = vec![
             "static-analysis".to_string(),
             "track:code-smell".to_string(),
         ];
 
-        let memory = MemoryNode {
-            id: id.clone(),
-            content: content.to_string(),
-            memory_type: MemoryType::Pattern,
-            importance: 0.5,
-            confidence: self.config.enrichment.insight_confidence,
-            access_count: 0,
-            content_hash: hash,
-            tags,
-            metadata: HashMap::from([
-                ("track".into(), json!("code-smell")),
-                ("generated_by".into(), json!("enrichment_pipeline")),
-            ]),
-            namespace: namespace.map(String::from),
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::new(content, MemoryType::Pattern);
+        memory.id = id.clone();
+        memory.confidence = self.config.enrichment.insight_confidence;
+        memory.tags = tags;
+        memory.metadata = HashMap::from([
+            ("track".into(), json!("code-smell")),
+            ("generated_by".into(), json!("enrichment_pipeline")),
+        ]);
+        memory.namespace = namespace.map(String::from);
 
         if self.persist_memory_no_save(&memory).is_err() {
             return None;

--- a/crates/codemem-engine/src/memory_ops.rs
+++ b/crates/codemem-engine/src/memory_ops.rs
@@ -204,30 +204,18 @@ impl CodememEngine {
         let new_tags = tags.unwrap_or_else(|| old_memory.tags.clone());
         let new_importance = importance.unwrap_or(old_memory.importance);
 
-        let now = chrono::Utc::now();
-        let new_id = uuid::Uuid::new_v4().to_string();
-        let hash = codemem_storage::Storage::content_hash(new_content);
-
-        let memory = MemoryNode {
-            id: new_id.clone(),
-            content: new_content.to_string(),
-            memory_type: old_memory.memory_type,
-            importance: new_importance,
-            confidence: old_memory.confidence,
-            access_count: 0,
-            content_hash: hash,
-            tags: new_tags,
-            metadata: old_memory.metadata.clone(),
-            namespace: old_memory.namespace.clone(),
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::new(new_content, old_memory.memory_type);
+        let new_id = memory.id.clone();
+        memory.importance = new_importance;
+        memory.confidence = old_memory.confidence;
+        memory.tags = new_tags;
+        memory.metadata = old_memory.metadata.clone();
+        memory.namespace = old_memory.namespace.clone();
 
         self.persist_memory(&memory)?;
 
         // Create EVOLVED_INTO edge from old -> new
+        let now = chrono::Utc::now();
         let edge = Edge {
             id: format!("{old_id}-EVOLVED_INTO-{new_id}"),
             src: old_id.to_string(),
@@ -282,25 +270,12 @@ impl CodememEngine {
                 .unwrap_or_else(|| source_memory.tags.clone());
             let importance = part.importance.unwrap_or(source_memory.importance);
 
-            let child_id = uuid::Uuid::new_v4().to_string();
-            let hash = codemem_storage::Storage::content_hash(&part.content);
-
-            let memory = MemoryNode {
-                id: child_id.clone(),
-                content: part.content.clone(),
-                memory_type: source_memory.memory_type,
-                importance,
-                confidence: source_memory.confidence,
-                access_count: 0,
-                content_hash: hash,
-                tags,
-                metadata: std::collections::HashMap::new(),
-                namespace: source_memory.namespace.clone(),
-                session_id: None,
-                created_at: now,
-                updated_at: now,
-                last_accessed_at: now,
-            };
+            let mut memory = MemoryNode::new(part.content.clone(), source_memory.memory_type);
+            let child_id = memory.id.clone();
+            memory.importance = importance;
+            memory.confidence = source_memory.confidence;
+            memory.tags = tags;
+            memory.namespace = source_memory.namespace.clone();
 
             if let Err(e) = self.persist_memory_no_save(&memory) {
                 // Clean up already-created child memories
@@ -369,30 +344,17 @@ impl CodememEngine {
             )));
         }
 
-        let now = chrono::Utc::now();
-        let merged_id = uuid::Uuid::new_v4().to_string();
-        let hash = codemem_storage::Storage::content_hash(content);
-
-        let memory = MemoryNode {
-            id: merged_id.clone(),
-            content: content.to_string(),
-            memory_type,
-            importance,
-            confidence: found.iter().map(|m| m.confidence).sum::<f64>() / found.len() as f64,
-            access_count: 0,
-            content_hash: hash,
-            tags,
-            metadata: std::collections::HashMap::new(),
-            namespace: found.iter().find_map(|m| m.namespace.clone()),
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::new(content, memory_type);
+        let merged_id = memory.id.clone();
+        memory.importance = importance;
+        memory.confidence = found.iter().map(|m| m.confidence).sum::<f64>() / found.len() as f64;
+        memory.tags = tags;
+        memory.namespace = found.iter().find_map(|m| m.namespace.clone());
 
         self.persist_memory_no_save(&memory)?;
 
         // Create SUMMARIZES edges: merged -> each source
+        let now = chrono::Utc::now();
         for source_id in source_ids {
             let edge = Edge {
                 id: format!("{merged_id}-SUMMARIZES-{source_id}"),

--- a/crates/codemem-engine/src/scoring.rs
+++ b/crates/codemem-engine/src/scoring.rs
@@ -57,19 +57,8 @@ pub fn graph_strength_for_memory(graph: &GraphEngine, memory_id: &str) -> f64 {
     score.min(1.0)
 }
 
-/// Truncate a string to `max` bytes, appending "..." if truncated.
-/// Handles multi-byte UTF-8 safely by finding the nearest char boundary.
-pub fn truncate_content(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        let mut end = max;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        format!("{}...", &s[..end])
-    }
-}
+/// Re-export the canonical truncate from codemem-core.
+pub use codemem_core::truncate as truncate_content;
 
 /// Compute 9-component hybrid score for a memory against a query.
 /// The `graph` parameter is used to look up edge counts for graph strength scoring.

--- a/crates/codemem-engine/src/tests/analysis_tests.rs
+++ b/crates/codemem-engine/src/tests/analysis_tests.rs
@@ -2,7 +2,6 @@ use crate::CodememEngine;
 use codemem_core::{
     Edge, GraphBackend, GraphNode, MemoryNode, MemoryType, NodeKind, RelationshipType,
 };
-use codemem_storage::Storage;
 use std::collections::HashMap;
 
 fn make_memory_typed(
@@ -11,23 +10,13 @@ fn make_memory_typed(
     memory_type: MemoryType,
     namespace: Option<&str>,
 ) -> MemoryNode {
-    let now = chrono::Utc::now();
-    MemoryNode {
-        id: id.to_string(),
-        content: content.to_string(),
-        memory_type,
-        importance: 0.7,
-        confidence: 0.9,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: namespace.map(String::from),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.id = id.to_string();
+    m.memory_type = memory_type;
+    m.importance = 0.7;
+    m.confidence = 0.9;
+    m.namespace = namespace.map(String::from);
+    m
 }
 
 // ── recall_with_impact ──────────────────────────────────────────────

--- a/crates/codemem-engine/src/tests/consolidation_tests.rs
+++ b/crates/codemem-engine/src/tests/consolidation_tests.rs
@@ -1,7 +1,5 @@
 use crate::CodememEngine;
 use codemem_core::{MemoryNode, MemoryType};
-use codemem_storage::Storage;
-use std::collections::HashMap;
 
 fn make_memory_with_opts(
     id: &str,
@@ -11,23 +9,14 @@ fn make_memory_with_opts(
     importance: f64,
     access_count: u32,
 ) -> MemoryNode {
-    let now = chrono::Utc::now();
-    MemoryNode {
-        id: id.to_string(),
-        content: content.to_string(),
-        memory_type,
-        importance,
-        confidence: 0.9,
-        access_count,
-        content_hash: Storage::content_hash(content),
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: namespace.map(String::from),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.id = id.to_string();
+    m.memory_type = memory_type;
+    m.importance = importance;
+    m.confidence = 0.9;
+    m.access_count = access_count;
+    m.namespace = namespace.map(String::from);
+    m
 }
 
 /// Create a memory with a timestamp in the past (days_ago days before now).
@@ -40,22 +29,16 @@ fn make_old_memory(
     days_ago: i64,
 ) -> MemoryNode {
     let past = chrono::Utc::now() - chrono::Duration::days(days_ago);
-    MemoryNode {
-        id: id.to_string(),
-        content: content.to_string(),
-        memory_type,
-        importance,
-        confidence: 0.9,
-        access_count,
-        content_hash: Storage::content_hash(content),
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: past,
-        updated_at: past,
-        last_accessed_at: past,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.id = id.to_string();
+    m.memory_type = memory_type;
+    m.importance = importance;
+    m.confidence = 0.9;
+    m.access_count = access_count;
+    m.created_at = past;
+    m.updated_at = past;
+    m.last_accessed_at = past;
+    m
 }
 
 /// Create a memory with specific tags.
@@ -66,23 +49,13 @@ fn make_tagged_memory(
     access_count: u32,
     tags: Vec<String>,
 ) -> MemoryNode {
-    let now = chrono::Utc::now();
-    MemoryNode {
-        id: id.to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance,
-        confidence: 0.9,
-        access_count,
-        content_hash: Storage::content_hash(content),
-        tags,
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.id = id.to_string();
+    m.importance = importance;
+    m.confidence = 0.9;
+    m.access_count = access_count;
+    m.tags = tags;
+    m
 }
 
 // ── Decay consolidation ─────────────────────────────────────────────

--- a/crates/codemem-engine/src/tests/engine_integration_tests.rs
+++ b/crates/codemem-engine/src/tests/engine_integration_tests.rs
@@ -1,28 +1,14 @@
 use crate::CodememEngine;
-use codemem_core::{
-    Edge, GraphBackend, GraphNode, MemoryNode, MemoryType, NodeKind, RelationshipType,
-};
-use codemem_storage::Storage;
+use codemem_core::{Edge, GraphBackend, GraphNode, MemoryNode, NodeKind, RelationshipType};
 use std::collections::HashMap;
 
 fn make_memory(id: &str, content: &str) -> MemoryNode {
-    let now = chrono::Utc::now();
-    MemoryNode {
-        id: id.to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.7,
-        confidence: 0.9,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: vec!["test".to_string()],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.id = id.to_string();
+    m.importance = 0.7;
+    m.confidence = 0.9;
+    m.tags = vec!["test".to_string()];
+    m
 }
 
 // ── Test #3: Dirty flag lifecycle ───────────────────────────────────

--- a/crates/codemem-engine/src/tests/graph_linking_tests.rs
+++ b/crates/codemem-engine/src/tests/graph_linking_tests.rs
@@ -2,7 +2,6 @@ use crate::CodememEngine;
 use codemem_core::{
     Edge, GraphBackend, GraphNode, MemoryNode, MemoryType, NodeKind, RelationshipType,
 };
-use codemem_storage::Storage;
 use std::collections::HashMap;
 
 fn make_memory(id: &str, content: &str) -> MemoryNode {
@@ -18,23 +17,14 @@ fn make_memory_with_opts(
     importance: f64,
     confidence: f64,
 ) -> MemoryNode {
-    let now = chrono::Utc::now();
-    MemoryNode {
-        id: id.to_string(),
-        content: content.to_string(),
-        memory_type,
-        importance,
-        confidence,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: tags.iter().map(|s| s.to_string()).collect(),
-        metadata: HashMap::new(),
-        namespace: namespace.map(String::from),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.id = id.to_string();
+    m.memory_type = memory_type;
+    m.importance = importance;
+    m.confidence = confidence;
+    m.tags = tags.iter().map(|s| s.to_string()).collect();
+    m.namespace = namespace.map(String::from);
+    m
 }
 
 /// Helper: add a graph node to both storage and in-memory graph.
@@ -357,23 +347,11 @@ fn auto_link_by_tags_duplicate_tags_linked_once() {
     engine.persist_memory(&m1).unwrap();
 
     // m2 has the same tag twice — the HashSet in auto_link_by_tags should dedup
-    let now = chrono::Utc::now();
-    let m2 = MemoryNode {
-        id: "tag-dup2".to_string(),
-        content: "second memory with dup tags".to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.7,
-        confidence: 0.9,
-        access_count: 0,
-        content_hash: Storage::content_hash("second memory with dup tags"),
-        tags: vec!["topic-x".to_string(), "topic-x".to_string()],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut m2 = MemoryNode::test_default("second memory with dup tags");
+    m2.id = "tag-dup2".to_string();
+    m2.importance = 0.7;
+    m2.confidence = 0.9;
+    m2.tags = vec!["topic-x".to_string(), "topic-x".to_string()];
     engine.persist_memory(&m2).unwrap();
 
     let graph = engine.lock_graph().unwrap();

--- a/crates/codemem-engine/src/tests/patterns_tests.rs
+++ b/crates/codemem-engine/src/tests/patterns_tests.rs
@@ -1,11 +1,9 @@
 use super::*;
 use codemem_core::MemoryNode;
-use codemem_core::MemoryType;
 use codemem_storage::Storage;
 use std::collections::HashMap;
 
 fn make_memory(content: &str, tool: &str, extra_metadata: Vec<(&str, &str)>) -> MemoryNode {
-    let now = chrono::Utc::now();
     let mut metadata = HashMap::new();
     metadata.insert(
         "tool".to_string(),
@@ -14,22 +12,9 @@ fn make_memory(content: &str, tool: &str, extra_metadata: Vec<(&str, &str)>) -> 
     for (k, v) in extra_metadata {
         metadata.insert(k.to_string(), serde_json::Value::String(v.to_string()));
     }
-    MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.5,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: codemem_storage::Storage::content_hash(content),
-        tags: vec![],
-        metadata,
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.metadata = metadata;
+    m
 }
 
 #[test]

--- a/crates/codemem-engine/src/tests/persistence_tests.rs
+++ b/crates/codemem-engine/src/tests/persistence_tests.rs
@@ -749,23 +749,12 @@ fn persist_cleans_stale_chunks_on_reindex() {
 // ── Memory ops provenance: refine_memory ────────────────────────────
 
 fn make_test_memory(id: &str, content: &str) -> codemem_core::MemoryNode {
-    let now = chrono::Utc::now();
-    codemem_core::MemoryNode {
-        id: id.to_string(),
-        content: content.to_string(),
-        memory_type: codemem_core::MemoryType::Insight,
-        importance: 0.5,
-        confidence: 0.8,
-        access_count: 0,
-        content_hash: codemem_storage::Storage::content_hash(content),
-        tags: vec!["test".to_string()],
-        metadata: std::collections::HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = codemem_core::MemoryNode::test_default(content);
+    m.id = id.to_string();
+    m.memory_type = codemem_core::MemoryType::Insight;
+    m.confidence = 0.8;
+    m.tags = vec!["test".to_string()];
+    m
 }
 
 #[test]

--- a/crates/codemem-engine/src/tests/recall_tests.rs
+++ b/crates/codemem-engine/src/tests/recall_tests.rs
@@ -1,6 +1,5 @@
 use crate::CodememEngine;
 use codemem_core::{Edge, GraphBackend, MemoryNode, MemoryType, RelationshipType};
-use codemem_storage::Storage;
 use std::collections::HashMap;
 
 fn make_memory(id: &str, content: &str) -> MemoryNode {
@@ -16,23 +15,14 @@ fn make_memory_with_opts(
     importance: f64,
     confidence: f64,
 ) -> MemoryNode {
-    let now = chrono::Utc::now();
-    MemoryNode {
-        id: id.to_string(),
-        content: content.to_string(),
-        memory_type,
-        importance,
-        confidence,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: tags.iter().map(|s| s.to_string()).collect(),
-        metadata: HashMap::new(),
-        namespace: namespace.map(String::from),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.id = id.to_string();
+    m.memory_type = memory_type;
+    m.importance = importance;
+    m.confidence = confidence;
+    m.tags = tags.iter().map(|s| s.to_string()).collect();
+    m.namespace = namespace.map(String::from);
+    m
 }
 
 // ── Basic recall ────────────────────────────────────────────────────

--- a/crates/codemem-engine/src/tests/scoring_tests.rs
+++ b/crates/codemem-engine/src/tests/scoring_tests.rs
@@ -77,22 +77,13 @@ fn all_nine_scoring_components_nonzero() {
     bm25.add_document(memory_id, content);
 
     // Create MemoryNode with all fields set for non-zero scoring
-    let memory = MemoryNode {
-        id: memory_id.to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Decision,
-        importance: 0.8,
-        confidence: 0.9,
-        access_count: 1,
-        content_hash: "hash".to_string(),
-        tags: vec!["process".to_string(), "request".to_string()],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = MemoryNode::test_default(content);
+    memory.id = memory_id.to_string();
+    memory.memory_type = MemoryType::Decision;
+    memory.importance = 0.8;
+    memory.confidence = 0.9;
+    memory.access_count = 1;
+    memory.tags = vec!["process".to_string(), "request".to_string()];
 
     let query_tokens = vec!["process", "request"];
     let breakdown = compute_score(&memory, &query_tokens, 0.75, &graph, &bm25, now);

--- a/crates/codemem-storage/src/backend.rs
+++ b/crates/codemem-storage/src/backend.rs
@@ -1,6 +1,6 @@
 //! `StorageBackend` trait implementation for Storage.
 
-use crate::{MemoryRow, Storage};
+use crate::{MapStorageErr, MemoryRow, Storage};
 use codemem_core::{
     CodememError, ConsolidationLogEntry, Edge, GraphNode, MemoryNode, NodeKind, Session,
     StorageBackend, StorageStats,
@@ -101,9 +101,7 @@ impl StorageBackend for Storage {
             placeholders.join(",")
         );
 
-        let mut stmt = conn
-            .prepare(&sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(&sql).storage_err()?;
 
         let params: Vec<&dyn rusqlite::types::ToSql> = ids
             .iter()
@@ -112,11 +110,11 @@ impl StorageBackend for Storage {
 
         let rows = stmt
             .query_map(params.as_slice(), MemoryRow::from_row)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let mut memories = Vec::new();
         for row in rows {
-            let row = row.map_err(|e| CodememError::Storage(e.to_string()))?;
+            let row = row.storage_err()?;
             memories.push(row.into_memory_node()?);
         }
         Ok(memories)
@@ -134,7 +132,7 @@ impl StorageBackend for Storage {
                 "DELETE FROM memory_embeddings WHERE memory_id = ?1",
                 [memory_id],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(deleted > 0)
     }
 
@@ -142,17 +140,17 @@ impl StorageBackend for Storage {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare("SELECT memory_id, embedding FROM memory_embeddings")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         let rows = stmt
             .query_map([], |row| {
                 let id: String = row.get(0)?;
                 let blob: Vec<u8> = row.get(1)?;
                 Ok((id, blob))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         let mut result = Vec::new();
         for row in rows {
-            let (id, blob) = row.map_err(|e| CodememError::Storage(e.to_string()))?;
+            let (id, blob) = row.storage_err()?;
             let floats: Vec<f32> = blob
                 .chunks_exact(4)
                 .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
@@ -212,7 +210,7 @@ impl StorageBackend for Storage {
                 "UPDATE memories SET importance = importance * ?1 WHERE last_accessed_at < ?2",
                 params![decay_factor, threshold_ts],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(rows)
     }
 
@@ -222,7 +220,7 @@ impl StorageBackend for Storage {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare("SELECT id, memory_type, tags FROM memories ORDER BY created_at DESC")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let rows = stmt
             .query_map([], |row| {
@@ -232,9 +230,9 @@ impl StorageBackend for Storage {
                     row.get::<_, String>(2)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(rows
             .into_iter()
@@ -254,7 +252,7 @@ impl StorageBackend for Storage {
                  INNER JOIN memories b ON substr(a.content_hash, 1, 16) = substr(b.content_hash, 1, 16)
                  WHERE a.id < b.id",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let rows = stmt
             .query_map([], |row| {
@@ -264,9 +262,9 @@ impl StorageBackend for Storage {
                     row.get::<_, f64>(2)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(rows)
     }
@@ -277,13 +275,13 @@ impl StorageBackend for Storage {
             .prepare(
                 "SELECT id FROM memories WHERE importance < ?1 AND access_count = 0 ORDER BY importance ASC, last_accessed_at ASC",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let ids = stmt
             .query_map(params![importance_threshold], |row| row.get(0))
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<String>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(ids)
     }
@@ -295,9 +293,7 @@ impl StorageBackend for Storage {
             return Ok(());
         }
         let conn = self.conn()?;
-        let tx = conn
-            .unchecked_transaction()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let tx = conn.unchecked_transaction().storage_err()?;
 
         const COLS: usize = 14;
         const BATCH: usize = 999 / COLS; // 71
@@ -331,12 +327,10 @@ impl StorageBackend for Storage {
 
             let refs: Vec<&dyn rusqlite::types::ToSql> =
                 param_values.iter().map(|p| p.as_ref()).collect();
-            tx.execute(&sql, refs.as_slice())
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+            tx.execute(&sql, refs.as_slice()).storage_err()?;
         }
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
         Ok(())
     }
 
@@ -345,9 +339,7 @@ impl StorageBackend for Storage {
             return Ok(());
         }
         let conn = self.conn()?;
-        let tx = conn
-            .unchecked_transaction()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let tx = conn.unchecked_transaction().storage_err()?;
 
         const COLS: usize = 2;
         const BATCH: usize = 999 / COLS; // 499
@@ -368,12 +360,10 @@ impl StorageBackend for Storage {
 
             let refs: Vec<&dyn rusqlite::types::ToSql> =
                 param_values.iter().map(|p| p.as_ref()).collect();
-            tx.execute(&sql, refs.as_slice())
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+            tx.execute(&sql, refs.as_slice()).storage_err()?;
         }
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
         Ok(())
     }
 
@@ -381,38 +371,34 @@ impl StorageBackend for Storage {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare("SELECT file_path, content_hash FROM file_hashes")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let rows = stmt
             .query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(rows.into_iter().collect())
     }
 
     fn save_file_hashes(&self, hashes: &HashMap<String, String>) -> Result<(), CodememError> {
         let conn = self.conn()?;
-        let tx = conn
-            .unchecked_transaction()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let tx = conn.unchecked_transaction().storage_err()?;
 
-        tx.execute("DELETE FROM file_hashes", [])
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.execute("DELETE FROM file_hashes", []).storage_err()?;
 
         for (path, hash) in hashes {
             tx.execute(
                 "INSERT INTO file_hashes (file_path, content_hash) VALUES (?1, ?2)",
                 params![path, hash],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         }
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
         Ok(())
     }
 
@@ -421,9 +407,7 @@ impl StorageBackend for Storage {
             return Ok(());
         }
         let conn = self.conn()?;
-        let tx = conn
-            .unchecked_transaction()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let tx = conn.unchecked_transaction().storage_err()?;
 
         const COLS: usize = 7;
         const BATCH: usize = 999 / COLS; // 142
@@ -450,12 +434,10 @@ impl StorageBackend for Storage {
 
             let refs: Vec<&dyn rusqlite::types::ToSql> =
                 param_values.iter().map(|p| p.as_ref()).collect();
-            tx.execute(&sql, refs.as_slice())
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+            tx.execute(&sql, refs.as_slice()).storage_err()?;
         }
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
         Ok(())
     }
 
@@ -464,9 +446,7 @@ impl StorageBackend for Storage {
             return Ok(());
         }
         let conn = self.conn()?;
-        let tx = conn
-            .unchecked_transaction()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let tx = conn.unchecked_transaction().storage_err()?;
 
         const COLS: usize = 9;
         const BATCH: usize = 999 / COLS; // 111
@@ -495,12 +475,10 @@ impl StorageBackend for Storage {
 
             let refs: Vec<&dyn rusqlite::types::ToSql> =
                 param_values.iter().map(|p| p.as_ref()).collect();
-            tx.execute(&sql, refs.as_slice())
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+            tx.execute(&sql, refs.as_slice()).storage_err()?;
         }
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
         Ok(())
     }
 
@@ -513,7 +491,7 @@ impl StorageBackend for Storage {
             .prepare(
                 "SELECT id, importance, access_count, last_accessed_at FROM memories WHERE last_accessed_at < ?1",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let rows = stmt
             .query_map(params![threshold_ts], |row| {
@@ -524,9 +502,9 @@ impl StorageBackend for Storage {
                     row.get::<_, i64>(3)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(rows)
     }
@@ -536,9 +514,7 @@ impl StorageBackend for Storage {
             return Ok(0);
         }
         let conn = self.conn()?;
-        let tx = conn
-            .unchecked_transaction()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let tx = conn.unchecked_transaction().storage_err()?;
 
         let mut count = 0usize;
         for (id, importance) in updates {
@@ -547,12 +523,11 @@ impl StorageBackend for Storage {
                     "UPDATE memories SET importance = ?1 WHERE id = ?2",
                     params![importance, id],
                 )
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+                .storage_err()?;
             count += rows;
         }
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
         Ok(count)
     }
 
@@ -564,10 +539,10 @@ impl StorageBackend for Storage {
                 params![ns],
                 |row| row.get(0),
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         } else {
             conn.query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
-                .map_err(|e| CodememError::Storage(e.to_string()))?
+                .storage_err()?
         };
         Ok(count as usize)
     }
@@ -582,15 +557,15 @@ impl StorageBackend for Storage {
                  LEFT JOIN memory_embeddings me ON m.id = me.memory_id
                  WHERE me.memory_id IS NULL",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let rows = stmt
             .query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(rows)
     }
@@ -637,9 +612,7 @@ impl StorageBackend for Storage {
 
         let refs: Vec<&dyn rusqlite::types::ToSql> =
             params_vec.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn
-            .prepare(&sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(&sql).storage_err()?;
 
         let rows = stmt
             .query_map(refs.as_slice(), |row| {
@@ -655,9 +628,9 @@ impl StorageBackend for Storage {
                     namespace: row.get(6)?,
                 })
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(rows)
     }
@@ -686,17 +659,15 @@ impl StorageBackend for Storage {
 
         let refs: Vec<&dyn rusqlite::types::ToSql> =
             param_values.iter().map(|p| p.as_ref()).collect();
-        let mut stmt = conn
-            .prepare(&sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(&sql).storage_err()?;
 
         let rows = stmt
             .query_map(refs.as_slice(), MemoryRow::from_row)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let mut result = Vec::new();
         for row in rows {
-            let mr = row.map_err(|e| CodememError::Storage(e.to_string()))?;
+            let mr = row.storage_err()?;
             result.push(mr.into_memory_node()?);
         }
 
@@ -721,8 +692,7 @@ impl StorageBackend for Storage {
 
     fn begin_transaction(&self) -> Result<(), CodememError> {
         let conn = self.conn()?;
-        conn.execute_batch("BEGIN IMMEDIATE")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        conn.execute_batch("BEGIN IMMEDIATE").storage_err()?;
         self.in_transaction
             .store(true, std::sync::atomic::Ordering::Release);
         Ok(())
@@ -730,8 +700,7 @@ impl StorageBackend for Storage {
 
     fn commit_transaction(&self) -> Result<(), CodememError> {
         let conn = self.conn()?;
-        conn.execute_batch("COMMIT")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        conn.execute_batch("COMMIT").storage_err()?;
         // Clear flag after COMMIT succeeds — if COMMIT fails, the flag
         // stays set so callers know a transaction is still active.
         self.in_transaction
@@ -743,8 +712,7 @@ impl StorageBackend for Storage {
         self.in_transaction
             .store(false, std::sync::atomic::Ordering::Release);
         let conn = self.conn()?;
-        conn.execute_batch("ROLLBACK")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        conn.execute_batch("ROLLBACK").storage_err()?;
         Ok(())
     }
 }

--- a/crates/codemem-storage/src/graph_persistence.rs
+++ b/crates/codemem-storage/src/graph_persistence.rs
@@ -1,6 +1,6 @@
 //! Graph node/edge CRUD and embedding storage on Storage.
 
-use crate::Storage;
+use crate::{MapStorageErr, Storage};
 use codemem_core::{CodememError, Edge, GraphNode, NodeKind, RelationshipType};
 use rusqlite::{params, OptionalExtension};
 use std::collections::HashMap;
@@ -91,7 +91,7 @@ impl Storage {
             "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding) VALUES (?1, ?2)",
             params![memory_id, blob],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
 
         Ok(())
     }
@@ -106,7 +106,7 @@ impl Storage {
                 |row| row.get(0),
             )
             .optional()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         match blob {
             Some(bytes) => {
@@ -140,7 +140,7 @@ impl Storage {
                 node.namespace,
             ],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
 
         Ok(())
     }
@@ -166,7 +166,7 @@ impl Storage {
             },
         )
         .optional()
-        .map_err(|e| CodememError::Storage(e.to_string()))?
+        .storage_err()?
         .map(|(id, kind_str, label, payload_str, centrality, memory_id, namespace)| {
             let kind: NodeKind = kind_str.parse().map_err(|e: CodememError| CodememError::Storage(e.to_string()))?;
             let payload: HashMap<String, serde_json::Value> =
@@ -189,7 +189,7 @@ impl Storage {
         let conn = self.conn()?;
         let rows = conn
             .execute("DELETE FROM graph_nodes WHERE id = ?1", params![id])
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(rows > 0)
     }
 
@@ -198,7 +198,7 @@ impl Storage {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare("SELECT id, kind, label, payload, centrality, memory_id, namespace FROM graph_nodes")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let rows = stmt
             .query_map([], |row| {
@@ -214,12 +214,12 @@ impl Storage {
                     row.get::<_, Option<String>>(6)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let mut nodes = Vec::new();
         for row_result in rows {
             let (id, kind_str, label, payload_str, centrality, memory_id, namespace) =
-                row_result.map_err(|e| CodememError::Storage(e.to_string()))?;
+                row_result.storage_err()?;
             let kind: NodeKind = match kind_str.parse() {
                 Ok(k) => k,
                 Err(_) => {
@@ -269,7 +269,7 @@ impl Storage {
                 edge.valid_to.map(|dt| dt.timestamp()),
             ],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
 
         Ok(())
     }
@@ -281,11 +281,11 @@ impl Storage {
             .prepare(
                 "SELECT id, src, dst, relationship, weight, properties, created_at, valid_from, valid_to FROM graph_edges WHERE src = ?1 OR dst = ?1",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let edges = stmt
             .query_map(params![node_id], extract_edge_tuple)
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .filter_map(|r| match r {
                 Ok(v) => Some(v),
                 Err(e) => {
@@ -304,11 +304,11 @@ impl Storage {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare("SELECT id, src, dst, relationship, weight, properties, created_at, valid_from, valid_to FROM graph_edges")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let edges = stmt
             .query_map([], extract_edge_tuple)
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .filter_map(|r| match r {
                 Ok(v) => Some(v),
                 Err(e) => {
@@ -330,7 +330,7 @@ impl Storage {
                 "DELETE FROM graph_edges WHERE src = ?1 OR dst = ?1",
                 params![node_id],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(rows)
     }
 
@@ -345,11 +345,11 @@ impl Storage {
                  INNER JOIN graph_nodes gd ON e.dst = gd.id
                  WHERE gs.namespace = ?1 AND gd.namespace = ?1",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let edges = stmt
             .query_map(params![namespace], extract_edge_tuple)
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .filter_map(|r| match r {
                 Ok(v) => Some(v),
                 Err(e) => {

--- a/crates/codemem-storage/src/lib.rs
+++ b/crates/codemem-storage/src/lib.rs
@@ -21,6 +21,17 @@ pub use graph::GraphEngine;
 pub use graph::RawGraphMetrics;
 pub use vector::HnswIndex;
 
+/// Extension trait for converting `rusqlite::Error` results into `CodememError::Storage`.
+pub(crate) trait MapStorageErr<T> {
+    fn storage_err(self) -> Result<T, CodememError>;
+}
+
+impl<T> MapStorageErr<T> for Result<T, rusqlite::Error> {
+    fn storage_err(self) -> Result<T, CodememError> {
+        self.map_err(|e| CodememError::Storage(e.to_string()))
+    }
+}
+
 /// SQLite-backed storage for Codemem memories, embeddings, and graph data.
 ///
 /// Wraps `rusqlite::Connection` in a `Mutex` to satisfy `Send + Sync` bounds
@@ -52,27 +63,27 @@ impl Storage {
     ) -> Result<(), CodememError> {
         // WAL mode for concurrent reads
         conn.pragma_update(None, "journal_mode", "WAL")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         // Cache size (negative value = KiB in SQLite)
         let cache_kb = i64::from(cache_size_mb.unwrap_or(64)) * 1000;
         conn.pragma_update(None, "cache_size", -cache_kb)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         // Foreign keys ON
         conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         // NORMAL sync (good balance of safety vs speed)
         conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         // 256MB mmap for faster reads
         conn.pragma_update(None, "mmap_size", 268435456i64)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         // Temp tables in memory
         conn.pragma_update(None, "temp_store", "MEMORY")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         // Busy timeout
         let timeout = busy_timeout_secs.unwrap_or(5);
         conn.busy_timeout(std::time::Duration::from_secs(timeout))
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(())
     }
 
@@ -87,7 +98,7 @@ impl Storage {
         cache_size_mb: Option<u32>,
         busy_timeout_secs: Option<u64>,
     ) -> Result<Self, CodememError> {
-        let conn = Connection::open(path).map_err(|e| CodememError::Storage(e.to_string()))?;
+        let conn = Connection::open(path).storage_err()?;
         Self::apply_pragmas(&conn, cache_size_mb, busy_timeout_secs)?;
         migrations::run_migrations(&conn)?;
         Ok(Self {
@@ -111,7 +122,7 @@ impl Storage {
         cache_size_mb: Option<u32>,
         busy_timeout_secs: Option<u64>,
     ) -> Result<Self, CodememError> {
-        let conn = Connection::open(path).map_err(|e| CodememError::Storage(e.to_string()))?;
+        let conn = Connection::open(path).storage_err()?;
         Self::apply_pragmas(&conn, cache_size_mb, busy_timeout_secs)?;
         Ok(Self {
             conn: Mutex::new(conn),
@@ -121,8 +132,7 @@ impl Storage {
 
     /// Open an in-memory database (for testing).
     pub fn open_in_memory() -> Result<Self, CodememError> {
-        let conn =
-            Connection::open_in_memory().map_err(|e| CodememError::Storage(e.to_string()))?;
+        let conn = Connection::open_in_memory().storage_err()?;
         Self::apply_pragmas(&conn, None, None)?;
         migrations::run_migrations(&conn)?;
         Ok(Self {

--- a/crates/codemem-storage/src/memory.rs
+++ b/crates/codemem-storage/src/memory.rs
@@ -1,8 +1,57 @@
 //! Memory CRUD operations on Storage.
 
-use crate::{MemoryRow, Storage};
+use crate::{MapStorageErr, MemoryRow, Storage};
 use codemem_core::{CodememError, MemoryNode, Repository};
 use rusqlite::{params, OptionalExtension};
+
+/// Shared dedup-check + INSERT logic used by both transactional and
+/// non-transactional insert paths.  Accepts `&rusqlite::Connection` because
+/// both `Connection` and `Transaction` deref to it.
+fn insert_memory_inner(
+    conn: &rusqlite::Connection,
+    memory: &MemoryNode,
+) -> Result<(), CodememError> {
+    // Check dedup (namespace-scoped)
+    let existing: Option<String> = conn
+        .query_row(
+            "SELECT id FROM memories WHERE content_hash = ?1 AND namespace IS ?2",
+            params![memory.content_hash, memory.namespace],
+            |row| row.get(0),
+        )
+        .optional()
+        .storage_err()?;
+
+    if existing.is_some() {
+        return Err(CodememError::Duplicate(memory.content_hash.clone()));
+    }
+
+    let tags_json = serde_json::to_string(&memory.tags)?;
+    let metadata_json = serde_json::to_string(&memory.metadata)?;
+
+    conn.execute(
+        "INSERT OR IGNORE INTO memories (id, content, memory_type, importance, confidence, access_count, content_hash, tags, metadata, namespace, session_id, created_at, updated_at, last_accessed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        params![
+            memory.id,
+            memory.content,
+            memory.memory_type.to_string(),
+            memory.importance,
+            memory.confidence,
+            memory.access_count,
+            memory.content_hash,
+            tags_json,
+            metadata_json,
+            memory.namespace,
+            memory.session_id,
+            memory.created_at.timestamp(),
+            memory.updated_at.timestamp(),
+            memory.last_accessed_at.timestamp(),
+        ],
+    )
+    .storage_err()?;
+
+    Ok(())
+}
 
 impl Storage {
     /// Insert a new memory. Returns Err(Duplicate) if content hash already exists.
@@ -26,51 +75,13 @@ impl Storage {
 
         let tx = conn
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
-        // Check dedup inside the transaction (namespace-scoped)
-        let existing: Option<String> = tx
-            .query_row(
-                "SELECT id FROM memories WHERE content_hash = ?1 AND namespace IS ?2",
-                params![memory.content_hash, memory.namespace],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        // Dedup check + INSERT inside the transaction; on Duplicate error the
+        // transaction is rolled back automatically when `tx` is dropped.
+        insert_memory_inner(&tx, memory)?;
 
-        if existing.is_some() {
-            tx.rollback()
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
-            return Err(CodememError::Duplicate(memory.content_hash.clone()));
-        }
-
-        let tags_json = serde_json::to_string(&memory.tags)?;
-        let metadata_json = serde_json::to_string(&memory.metadata)?;
-
-        tx.execute(
-            "INSERT OR IGNORE INTO memories (id, content, memory_type, importance, confidence, access_count, content_hash, tags, metadata, namespace, session_id, created_at, updated_at, last_accessed_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
-            params![
-                memory.id,
-                memory.content,
-                memory.memory_type.to_string(),
-                memory.importance,
-                memory.confidence,
-                memory.access_count,
-                memory.content_hash,
-                tags_json,
-                metadata_json,
-                memory.namespace,
-                memory.session_id,
-                memory.created_at.timestamp(),
-                memory.updated_at.timestamp(),
-                memory.last_accessed_at.timestamp(),
-            ],
-        )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
-
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
 
         Ok(())
     }
@@ -79,47 +90,7 @@ impl Storage {
     /// Used when an outer transaction is already active.
     fn insert_memory_no_tx(&self, memory: &MemoryNode) -> Result<(), CodememError> {
         let conn = self.conn()?;
-
-        // Check dedup (namespace-scoped) — outer transaction provides atomicity
-        let existing: Option<String> = conn
-            .query_row(
-                "SELECT id FROM memories WHERE content_hash = ?1 AND namespace IS ?2",
-                params![memory.content_hash, memory.namespace],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
-
-        if existing.is_some() {
-            return Err(CodememError::Duplicate(memory.content_hash.clone()));
-        }
-
-        let tags_json = serde_json::to_string(&memory.tags)?;
-        let metadata_json = serde_json::to_string(&memory.metadata)?;
-
-        conn.execute(
-            "INSERT OR IGNORE INTO memories (id, content, memory_type, importance, confidence, access_count, content_hash, tags, metadata, namespace, session_id, created_at, updated_at, last_accessed_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
-            params![
-                memory.id,
-                memory.content,
-                memory.memory_type.to_string(),
-                memory.importance,
-                memory.confidence,
-                memory.access_count,
-                memory.content_hash,
-                tags_json,
-                metadata_json,
-                memory.namespace,
-                memory.session_id,
-                memory.created_at.timestamp(),
-                memory.updated_at.timestamp(),
-                memory.last_accessed_at.timestamp(),
-            ],
-        )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
-
-        Ok(())
+        insert_memory_inner(&conn, memory)
     }
 
     /// Get a memory by ID. Updates access_count and last_accessed_at.
@@ -132,7 +103,7 @@ impl Storage {
                 "UPDATE memories SET access_count = access_count + 1, last_accessed_at = ?1 WHERE id = ?2",
                 params![chrono::Utc::now().timestamp(), id],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         if updated == 0 {
             return Ok(None);
@@ -145,7 +116,7 @@ impl Storage {
                 MemoryRow::from_row,
             )
             .optional()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         match result {
             Some(row) => Ok(Some(row.into_memory_node()?)),
@@ -165,7 +136,7 @@ impl Storage {
                 MemoryRow::from_row,
             )
             .optional()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         match result {
             Some(row) => Ok(Some(row.into_memory_node()?)),
@@ -189,13 +160,13 @@ impl Storage {
                 "UPDATE memories SET content = ?1, content_hash = ?2, updated_at = ?3, importance = ?4 WHERE id = ?5",
                 params![content, hash, now, imp, id],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         } else {
             conn.execute(
                 "UPDATE memories SET content = ?1, content_hash = ?2, updated_at = ?3 WHERE id = ?4",
                 params![content, hash, now, id],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         };
 
         if rows_affected == 0 {
@@ -210,7 +181,7 @@ impl Storage {
         let conn = self.conn()?;
         let rows = conn
             .execute("DELETE FROM memories WHERE id = ?1", params![id])
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(rows > 0)
     }
 
@@ -222,7 +193,7 @@ impl Storage {
         // avoiding potential deadlock with DEFERRED transaction.
         let tx = conn
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         // Delete edges that reference graph nodes linked to this memory
         tx.execute(
@@ -230,26 +201,25 @@ impl Storage {
              OR dst IN (SELECT id FROM graph_nodes WHERE memory_id = ?1)",
             params![id],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
 
         // Delete graph nodes linked to this memory
         tx.execute("DELETE FROM graph_nodes WHERE memory_id = ?1", params![id])
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         // Delete embedding
         tx.execute(
             "DELETE FROM memory_embeddings WHERE memory_id = ?1",
             params![id],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
 
         // Delete the memory itself
         let rows = tx
             .execute("DELETE FROM memories WHERE id = ?1", params![id])
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
 
         Ok(rows > 0)
     }
@@ -264,7 +234,7 @@ impl Storage {
         let mut conn = self.conn()?;
         let tx = conn
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let placeholders: String = (1..=ids.len())
             .map(|i| format!("?{i}"))
@@ -283,29 +253,23 @@ impl Storage {
              OR dst IN (SELECT id FROM graph_nodes WHERE memory_id IN ({placeholders})) \
              OR src IN ({placeholders}) OR dst IN ({placeholders})"
         );
-        tx.execute(&edge_sql, params.as_slice())
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.execute(&edge_sql, params.as_slice()).storage_err()?;
 
         // Delete graph nodes linked to these memories (by memory_id column or by id)
         let node_sql = format!(
             "DELETE FROM graph_nodes WHERE memory_id IN ({placeholders}) OR id IN ({placeholders})"
         );
-        tx.execute(&node_sql, params.as_slice())
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.execute(&node_sql, params.as_slice()).storage_err()?;
 
         // Delete embeddings
         let emb_sql = format!("DELETE FROM memory_embeddings WHERE memory_id IN ({placeholders})");
-        tx.execute(&emb_sql, params.as_slice())
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.execute(&emb_sql, params.as_slice()).storage_err()?;
 
         // Delete the memories themselves
         let mem_sql = format!("DELETE FROM memories WHERE id IN ({placeholders})");
-        let deleted = tx
-            .execute(&mem_sql, params.as_slice())
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let deleted = tx.execute(&mem_sql, params.as_slice()).storage_err()?;
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
 
         Ok(deleted)
     }
@@ -331,18 +295,16 @@ impl Storage {
                 ("SELECT id FROM memories ORDER BY created_at DESC", vec![])
             };
 
-        let mut stmt = conn
-            .prepare(sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(sql).storage_err()?;
 
         let refs: Vec<&dyn rusqlite::types::ToSql> =
             params_vec.iter().map(|p| p.as_ref()).collect();
 
         let ids = stmt
             .query_map(refs.as_slice(), |row| row.get(0))
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<String>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(ids)
     }
@@ -355,13 +317,13 @@ impl Storage {
         let conn = self.conn()?;
         let mut stmt = conn
             .prepare("SELECT id FROM memories WHERE namespace = ?1 ORDER BY created_at DESC")
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let ids = stmt
             .query_map(params![namespace], |row| row.get(0))
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<String>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(ids)
     }
@@ -377,13 +339,13 @@ impl Storage {
                     SELECT namespace FROM graph_nodes WHERE namespace IS NOT NULL
                 ) ORDER BY namespace",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let namespaces = stmt
             .query_map([], |row| row.get(0))
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<String>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(namespaces)
     }
@@ -393,7 +355,7 @@ impl Storage {
         let conn = self.conn()?;
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(count as usize)
     }
 
@@ -406,7 +368,7 @@ impl Storage {
             .prepare(
                 "SELECT id, path, name, namespace, created_at, last_indexed_at, status FROM repositories ORDER BY created_at DESC",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let repos = stmt
             .query_map([], |row| {
@@ -423,9 +385,9 @@ impl Storage {
                         .unwrap_or_else(|| "idle".to_string()),
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let mut result = Vec::new();
         for (id, path, name, namespace, created_at, last_indexed_at, status) in repos {
@@ -458,7 +420,7 @@ impl Storage {
                 repo.status,
             ],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
         Ok(())
     }
 
@@ -467,7 +429,7 @@ impl Storage {
         let conn = self.conn()?;
         let rows = conn
             .execute("DELETE FROM repositories WHERE id = ?1", params![id])
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(rows > 0)
     }
 
@@ -491,7 +453,7 @@ impl Storage {
                 },
             )
             .optional()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         match result {
             Some((id, path, name, namespace, created_at, last_indexed_at, status)) => {
@@ -522,13 +484,13 @@ impl Storage {
                 "UPDATE repositories SET status = ?1, last_indexed_at = ?2 WHERE id = ?3",
                 params![status, ts, id],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         } else {
             conn.execute(
                 "UPDATE repositories SET status = ?1 WHERE id = ?2",
                 params![status, id],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         }
         Ok(())
     }

--- a/crates/codemem-storage/src/migrations.rs
+++ b/crates/codemem-storage/src/migrations.rs
@@ -1,3 +1,4 @@
+use crate::MapStorageErr;
 use codemem_core::CodememError;
 use rusqlite::Connection;
 
@@ -60,7 +61,7 @@ pub(crate) fn run_migrations(conn: &Connection) -> Result<(), CodememError> {
             applied_at INTEGER NOT NULL
         );",
     )
-    .map_err(|e| CodememError::Storage(e.to_string()))?;
+    .storage_err()?;
 
     // Get current version
     let current_version: u32 = conn
@@ -69,7 +70,7 @@ pub(crate) fn run_migrations(conn: &Connection) -> Result<(), CodememError> {
             [],
             |row| row.get(0),
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
 
     // Run unapplied migrations, each wrapped in an EXCLUSIVE transaction
     // so migration SQL + version INSERT are atomic.
@@ -80,9 +81,7 @@ pub(crate) fn run_migrations(conn: &Connection) -> Result<(), CodememError> {
                 migration.version,
                 migration.description
             );
-            let tx = conn
-                .unchecked_transaction()
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+            let tx = conn.unchecked_transaction().storage_err()?;
 
             tx.execute_batch(migration.sql).map_err(|e| {
                 CodememError::Storage(format!(
@@ -98,10 +97,9 @@ pub(crate) fn run_migrations(conn: &Connection) -> Result<(), CodememError> {
                     chrono::Utc::now().timestamp()
                 ],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
-            tx.commit()
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+            tx.commit().storage_err()?;
         }
     }
 

--- a/crates/codemem-storage/src/queries.rs
+++ b/crates/codemem-storage/src/queries.rs
@@ -1,6 +1,6 @@
 //! Stats, consolidation, pattern queries, and session management on Storage.
 
-use crate::Storage;
+use crate::{MapStorageErr, Storage};
 use codemem_core::{CodememError, ConsolidationLogEntry, Session, StorageStats};
 use rusqlite::params;
 
@@ -12,7 +12,7 @@ impl Storage {
         let conn = self.conn()?;
         let result: String = conn
             .query_row("PRAGMA integrity_check", [], |row| row.get(0))
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(result == "ok")
     }
 
@@ -25,7 +25,7 @@ impl Storage {
                 [],
                 |row| row.get(0),
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(version)
     }
 
@@ -52,7 +52,7 @@ impl Storage {
                     ))
                 },
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(StorageStats {
             memory_count: memory_count as usize,
@@ -76,7 +76,7 @@ impl Storage {
             "INSERT INTO consolidation_log (cycle_type, run_at, affected_count) VALUES (?1, ?2, ?3)",
             params![cycle_type, now, affected_count as i64],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
         Ok(())
     }
 
@@ -91,7 +91,7 @@ impl Storage {
                  )
                  ORDER BY cycle_type",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let entries = stmt
             .query_map([], |row| {
@@ -101,9 +101,9 @@ impl Storage {
                     affected_count: row.get::<_, i64>(2)? as usize,
                 })
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(entries)
     }
@@ -142,9 +142,7 @@ impl Storage {
              ORDER BY cnt DESC"
         };
 
-        let mut stmt = conn
-            .prepare(sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(sql).storage_err()?;
 
         let rows = if let Some(ns) = namespace {
             stmt.query_map(params![ns, min_count as i64], |row| {
@@ -154,9 +152,9 @@ impl Storage {
                     row.get::<_, String>(2)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         } else {
             stmt.query_map(params![min_count as i64], |row| {
                 Ok((
@@ -165,9 +163,9 @@ impl Storage {
                     row.get::<_, String>(2)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         };
 
         Ok(rows
@@ -207,9 +205,7 @@ impl Storage {
              ORDER BY cnt DESC"
         };
 
-        let mut stmt = conn
-            .prepare(sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(sql).storage_err()?;
 
         let rows = if let Some(ns) = namespace {
             stmt.query_map(params![ns, min_count as i64], |row| {
@@ -219,9 +215,9 @@ impl Storage {
                     row.get::<_, String>(2)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         } else {
             stmt.query_map(params![min_count as i64], |row| {
                 Ok((
@@ -230,9 +226,9 @@ impl Storage {
                     row.get::<_, String>(2)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         };
 
         Ok(rows
@@ -268,24 +264,22 @@ impl Storage {
              ORDER BY cnt DESC"
         };
 
-        let mut stmt = conn
-            .prepare(sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(sql).storage_err()?;
 
         let rows = if let Some(ns) = namespace {
             stmt.query_map(params![ns], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         } else {
             stmt.query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         };
 
         Ok(rows
@@ -324,9 +318,7 @@ impl Storage {
              ORDER BY cnt DESC"
         };
 
-        let mut stmt = conn
-            .prepare(sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(sql).storage_err()?;
 
         let rows = if let Some(ns) = namespace {
             stmt.query_map(params![ns, min_count as i64], |row| {
@@ -336,9 +328,9 @@ impl Storage {
                     row.get::<_, String>(2)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         } else {
             stmt.query_map(params![min_count as i64], |row| {
                 Ok((
@@ -347,9 +339,9 @@ impl Storage {
                     row.get::<_, String>(2)?,
                 ))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
         };
 
         Ok(rows
@@ -407,9 +399,7 @@ impl Storage {
         let params_refs: Vec<&dyn rusqlite::types::ToSql> =
             params_vec.iter().map(|b| &**b).collect();
 
-        let mut stmt = conn
-            .prepare(&sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(&sql).storage_err()?;
 
         let rows = stmt
             .query_map(params_refs.as_slice(), |row| {
@@ -445,9 +435,9 @@ impl Storage {
                         .with_timezone(&chrono::Utc),
                 })
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(rows)
     }
@@ -462,7 +452,7 @@ impl Storage {
             "INSERT OR IGNORE INTO sessions (id, namespace, started_at) VALUES (?1, ?2, ?3)",
             params![id, namespace, now],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
         Ok(())
     }
 
@@ -474,7 +464,7 @@ impl Storage {
             "UPDATE sessions SET ended_at = ?1, summary = ?2 WHERE id = ?3",
             params![now, summary, id],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
         Ok(())
     }
 
@@ -501,7 +491,7 @@ impl Storage {
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![session_id, tool_name, file_path, directory, pattern, now],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
         Ok(())
     }
 
@@ -531,7 +521,7 @@ impl Storage {
                     ))
                 },
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(codemem_core::SessionActivitySummary {
             files_read: files_read as usize,
@@ -554,15 +544,15 @@ impl Storage {
                  WHERE session_id = ?1 AND directory IS NOT NULL
                  GROUP BY directory ORDER BY cnt DESC LIMIT ?2",
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         let rows = stmt
             .query_map(params![session_id, limit as i64], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
             })
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(rows
             .into_iter()
@@ -586,7 +576,7 @@ impl Storage {
                 params![session_id, dedup_tag],
                 |row| row.get(0),
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(count > 0)
     }
 
@@ -604,7 +594,7 @@ impl Storage {
                 params![session_id, directory],
                 |row| row.get(0),
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(count as usize)
     }
 
@@ -622,7 +612,7 @@ impl Storage {
                 params![session_id, file_path],
                 |row| row.get(0),
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(count > 0)
     }
 
@@ -640,7 +630,7 @@ impl Storage {
                 params![session_id, pattern],
                 |row| row.get(0),
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
         Ok(count as usize)
     }
 
@@ -672,23 +662,17 @@ impl Storage {
         };
 
         if let Some(ns) = namespace {
-            let mut stmt = conn
-                .prepare(sql_with_ns)
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+            let mut stmt = conn.prepare(sql_with_ns).storage_err()?;
             let rows = stmt
                 .query_map(params![ns, limit as i64], map_row)
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
-            rows.collect::<Result<Vec<_>, _>>()
-                .map_err(|e| CodememError::Storage(e.to_string()))
+                .storage_err()?;
+            rows.collect::<Result<Vec<_>, _>>().storage_err()
         } else {
-            let mut stmt = conn
-                .prepare(sql_all)
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
+            let mut stmt = conn.prepare(sql_all).storage_err()?;
             let rows = stmt
                 .query_map(params![limit as i64], map_row)
-                .map_err(|e| CodememError::Storage(e.to_string()))?;
-            rows.collect::<Result<Vec<_>, _>>()
-                .map_err(|e| CodememError::Storage(e.to_string()))
+                .storage_err()?;
+            rows.collect::<Result<Vec<_>, _>>().storage_err()
         }
     }
 
@@ -735,15 +719,13 @@ impl Storage {
         let refs: Vec<&dyn rusqlite::types::ToSql> =
             params_vec.iter().map(|p| p.as_ref()).collect();
 
-        let mut stmt = conn
-            .prepare(&sql)
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let mut stmt = conn.prepare(&sql).storage_err()?;
 
         let ids = stmt
             .query_map(refs.as_slice(), |row| row.get(0))
-            .map_err(|e| CodememError::Storage(e.to_string()))?
+            .storage_err()?
             .collect::<Result<Vec<String>, _>>()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
         Ok(ids)
     }
@@ -757,23 +739,21 @@ impl Storage {
         let conn = self.conn()?;
         let like_pattern = format!("{prefix}%");
 
-        let tx = conn
-            .unchecked_transaction()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        let tx = conn.unchecked_transaction().storage_err()?;
 
         // Delete edges where src or dst matches prefix
         tx.execute(
             "DELETE FROM graph_edges WHERE src LIKE ?1 OR dst LIKE ?1",
             params![like_pattern],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
 
         // Delete embeddings for matching nodes
         tx.execute(
             "DELETE FROM memory_embeddings WHERE memory_id LIKE ?1",
             params![like_pattern],
         )
-        .map_err(|e| CodememError::Storage(e.to_string()))?;
+        .storage_err()?;
 
         // Delete the nodes themselves
         let rows = tx
@@ -781,10 +761,9 @@ impl Storage {
                 "DELETE FROM graph_nodes WHERE id LIKE ?1",
                 params![like_pattern],
             )
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+            .storage_err()?;
 
-        tx.commit()
-            .map_err(|e| CodememError::Storage(e.to_string()))?;
+        tx.commit().storage_err()?;
 
         Ok(rows)
     }

--- a/crates/codemem-storage/src/tests/backend_tests.rs
+++ b/crates/codemem-storage/src/tests/backend_tests.rs
@@ -3,24 +3,10 @@ use codemem_core::{MemoryNode, MemoryType, StorageBackend};
 use std::collections::HashMap;
 
 fn test_memory() -> MemoryNode {
-    let now = chrono::Utc::now();
-    let content = "Test memory content";
-    MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.7,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: vec!["test".to_string()],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::new("Test memory content", MemoryType::Context);
+    m.importance = 0.7;
+    m.tags = vec!["test".to_string()];
+    m
 }
 
 #[test]

--- a/crates/codemem-storage/src/tests/graph_persistence_tests.rs
+++ b/crates/codemem-storage/src/tests/graph_persistence_tests.rs
@@ -3,24 +3,10 @@ use codemem_core::{GraphNode, MemoryNode, MemoryType, NodeKind};
 use std::collections::HashMap;
 
 fn test_memory() -> MemoryNode {
-    let now = chrono::Utc::now();
-    let content = "Test memory content";
-    MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.7,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: vec!["test".to_string()],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::new("Test memory content", MemoryType::Context);
+    m.importance = 0.7;
+    m.tags = vec!["test".to_string()];
+    m
 }
 
 #[test]

--- a/crates/codemem-storage/src/tests/memory_tests.rs
+++ b/crates/codemem-storage/src/tests/memory_tests.rs
@@ -5,24 +5,10 @@ use codemem_core::{
 use std::collections::HashMap;
 
 fn test_memory() -> MemoryNode {
-    let now = chrono::Utc::now();
-    let content = "Test memory content";
-    MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.7,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: vec!["test".to_string()],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::new("Test memory content", MemoryType::Context);
+    m.importance = 0.7;
+    m.tags = vec!["test".to_string()];
+    m
 }
 
 #[test]
@@ -173,41 +159,12 @@ fn dedup_null_namespace_coalesce() {
 fn same_hash_different_namespaces_both_succeed() {
     let storage = Storage::open_in_memory().unwrap();
     let content = "identical content for ns test";
-    let now = chrono::Utc::now();
 
-    let m1 = MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.5,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: Some("project-a".to_string()),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut m1 = MemoryNode::new(content, MemoryType::Context);
+    m1.namespace = Some("project-a".to_string());
 
-    let m2 = MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.5,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: Some("project-b".to_string()),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut m2 = MemoryNode::new(content, MemoryType::Context);
+    m2.namespace = Some("project-b".to_string());
 
     storage.insert_memory(&m1).unwrap();
     storage.insert_memory(&m2).unwrap();

--- a/crates/codemem-storage/src/tests/queries_tests.rs
+++ b/crates/codemem-storage/src/tests/queries_tests.rs
@@ -1,5 +1,5 @@
 use crate::Storage;
-use codemem_core::{MemoryNode, MemoryType};
+use codemem_core::MemoryNode;
 use std::collections::HashMap;
 
 fn test_memory_with_metadata(
@@ -7,28 +7,14 @@ fn test_memory_with_metadata(
     tool: &str,
     extra: HashMap<String, serde_json::Value>,
 ) -> MemoryNode {
-    let now = chrono::Utc::now();
     let mut metadata = extra;
     metadata.insert(
         "tool".to_string(),
         serde_json::Value::String(tool.to_string()),
     );
-    MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.5,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags: vec![],
-        metadata,
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.metadata = metadata;
+    m
 }
 
 #[test]
@@ -256,23 +242,10 @@ fn start_session_ignores_duplicate() {
 // ── find_memory_ids_by_tag Tests ────────────────────────────────────
 
 fn tagged_memory(content: &str, tags: Vec<String>, namespace: Option<String>) -> MemoryNode {
-    let now = chrono::Utc::now();
-    MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.5,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: Storage::content_hash(content),
-        tags,
-        metadata: HashMap::new(),
-        namespace,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    let mut m = MemoryNode::test_default(content);
+    m.tags = tags;
+    m.namespace = namespace;
+    m
 }
 
 #[test]

--- a/crates/codemem/src/api/routes/memories.rs
+++ b/crates/codemem/src/api/routes/memories.rs
@@ -58,31 +58,17 @@ pub async fn store_memory(
     State(state): State<Arc<AppState>>,
     Json(req): Json<StoreMemoryRequest>,
 ) -> Result<(StatusCode, Json<IdResponse>), (StatusCode, Json<MessageResponse>)> {
-    let now = chrono::Utc::now();
-    let id = uuid::Uuid::new_v4().to_string();
     let memory_type = req
         .memory_type
         .as_deref()
         .and_then(|t| t.parse::<MemoryType>().ok())
         .unwrap_or(MemoryType::Context);
-    let hash = codemem_storage::Storage::content_hash(&req.content);
 
-    let memory = MemoryNode {
-        id: id.clone(),
-        content: req.content.clone(),
-        memory_type,
-        importance: req.importance.unwrap_or(0.5),
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: hash,
-        tags: req.tags.unwrap_or_default(),
-        metadata: Default::default(),
-        namespace: req.namespace,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = MemoryNode::new(req.content.clone(), memory_type);
+    let id = memory.id.clone();
+    memory.importance = req.importance.unwrap_or(0.5);
+    memory.tags = req.tags.unwrap_or_default();
+    memory.namespace = req.namespace;
 
     // Use the engine's full persist pipeline: storage → BM25 → graph → embedding → vector
     if let Err(e) = state.server.engine.persist_memory(&memory) {

--- a/crates/codemem/src/cli/commands_data.rs
+++ b/crates/codemem/src/cli/commands_data.rs
@@ -201,8 +201,6 @@ pub(crate) fn cmd_ingest() -> anyhow::Result<()> {
 
         // Dedup on raw content hash (before compression) for consistency
         let hash = codemem_engine::hooks::content_hash(&extracted.content);
-        let now = chrono::Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
 
         // Compress observation via LLM if configured
         let compressor = codemem_engine::compress::CompressProvider::from_env();
@@ -238,22 +236,13 @@ pub(crate) fn cmd_ingest() -> anyhow::Result<()> {
             .ok()
             .map(|p| p.to_string_lossy().to_string());
 
-        let memory = codemem_core::MemoryNode {
-            id: id.clone(),
-            content: content.clone(),
-            memory_type: extracted.memory_type,
-            importance: 0.5,
-            confidence: 1.0,
-            access_count: 0,
-            content_hash: hash,
-            tags: extracted.tags,
-            metadata: extracted.metadata,
-            namespace: namespace.clone(),
-            session_id: extracted.session_id.clone(),
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = codemem_core::MemoryNode::new(content.clone(), extracted.memory_type);
+        let id = memory.id.clone();
+        memory.content_hash = hash;
+        memory.tags = extracted.tags;
+        memory.metadata = extracted.metadata;
+        memory.namespace = namespace.clone();
+        memory.session_id = extracted.session_id.clone();
 
         // Use engine.persist_memory() for the full pipeline (storage + BM25 + graph + embedding + vector)
         match engine.persist_memory(&memory) {
@@ -290,9 +279,6 @@ pub(crate) fn cmd_ingest() -> anyhow::Result<()> {
                             search_pattern.as_deref(),
                         );
                         for insight in &auto_insights {
-                            let insight_hash =
-                                codemem_engine::hooks::content_hash(&insight.content);
-                            let insight_now = chrono::Utc::now();
                             let mut insight_metadata = std::collections::HashMap::new();
                             insight_metadata.insert(
                                 "session_id".to_string(),
@@ -306,22 +292,16 @@ pub(crate) fn cmd_ingest() -> anyhow::Result<()> {
                                 "source".to_string(),
                                 serde_json::Value::String("auto_insight".to_string()),
                             );
-                            let insight_memory = codemem_core::MemoryNode {
-                                id: uuid::Uuid::new_v4().to_string(),
-                                content: insight.content.clone(),
-                                memory_type: codemem_core::MemoryType::Insight,
-                                importance: insight.importance,
-                                confidence: 0.8,
-                                access_count: 0,
-                                content_hash: insight_hash,
-                                tags: insight.tags.clone(),
-                                metadata: insight_metadata,
-                                namespace: namespace.clone(),
-                                session_id: payload.session_id.clone(),
-                                created_at: insight_now,
-                                updated_at: insight_now,
-                                last_accessed_at: insight_now,
-                            };
+                            let mut insight_memory = codemem_core::MemoryNode::new(
+                                insight.content.clone(),
+                                codemem_core::MemoryType::Insight,
+                            );
+                            insight_memory.importance = insight.importance;
+                            insight_memory.confidence = 0.8;
+                            insight_memory.tags = insight.tags.clone();
+                            insight_memory.metadata = insight_metadata;
+                            insight_memory.namespace = namespace.clone();
+                            insight_memory.session_id = payload.session_id.clone();
                             match engine.persist_memory(&insight_memory) {
                                 Ok(()) => {
                                     tracing::info!("Auto-insight stored: {}", insight.dedup_tag);
@@ -553,7 +533,6 @@ fn flush_batch(
         return 0;
     }
 
-    let now = chrono::Utc::now();
     let id = uuid::Uuid::new_v4().to_string();
 
     // Count by event type (created/deleted already computed above for threshold check)
@@ -712,24 +691,12 @@ fn flush_batch(
     // Importance scales with batch size: more files = more significant change
     let importance = batch_importance(batch.len());
 
-    let hash = codemem_storage::Storage::content_hash(&content);
-
-    let memory = codemem_core::MemoryNode {
-        id: id.clone(),
-        content,
-        memory_type: codemem_core::MemoryType::Context,
-        importance,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: hash,
-        tags,
-        metadata,
-        namespace: Some(watch_dir.to_string_lossy().to_string()),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::new(content, codemem_core::MemoryType::Context);
+    memory.id = id.clone();
+    memory.importance = importance;
+    memory.tags = tags;
+    memory.metadata = metadata;
+    memory.namespace = Some(watch_dir.to_string_lossy().to_string());
 
     match engine.persist_memory(&memory) {
         Ok(()) => {

--- a/crates/codemem/src/cli/commands_export.rs
+++ b/crates/codemem/src/cli/commands_export.rs
@@ -279,26 +279,12 @@ pub(crate) fn cmd_import(
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or_default();
 
-        let now = chrono::Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
-        let hash = codemem_storage::Storage::content_hash(&content);
-
-        let memory = codemem_core::MemoryNode {
-            id,
-            content,
-            memory_type,
-            importance,
-            confidence,
-            access_count: 0,
-            content_hash: hash,
-            tags,
-            metadata,
-            namespace,
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = codemem_core::MemoryNode::new(content, memory_type);
+        memory.importance = importance;
+        memory.confidence = confidence;
+        memory.tags = tags;
+        memory.metadata = metadata;
+        memory.namespace = namespace;
 
         match engine.persist_memory(&memory) {
             Ok(()) => {

--- a/crates/codemem/src/cli/commands_lifecycle.rs
+++ b/crates/codemem/src/cli/commands_lifecycle.rs
@@ -386,38 +386,25 @@ pub(crate) fn cmd_prompt() -> anyhow::Result<()> {
     // Store prompt as a Context memory via the full persist pipeline
     // (BM25 + graph node + embedding + auto-linking)
     let content = format!("User prompt: {}", crate::truncate_str(prompt, 2000));
-    let content_hash = codemem_engine::hooks::content_hash(&content);
 
-    let now = chrono::Utc::now();
-    let memory = codemem_core::MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content,
-        memory_type: codemem_core::MemoryType::Context,
-        importance: 0.3,
-        confidence: 1.0,
-        tags: vec!["prompt".to_string()],
-        metadata: {
-            let mut m = std::collections::HashMap::new();
+    let mut memory = codemem_core::MemoryNode::new(content, codemem_core::MemoryType::Context);
+    memory.importance = 0.3;
+    memory.tags = vec!["prompt".to_string()];
+    memory.metadata = {
+        let mut m = std::collections::HashMap::new();
+        m.insert(
+            "source".to_string(),
+            serde_json::Value::String("UserPromptSubmit".to_string()),
+        );
+        if let Some(sid) = session_id {
             m.insert(
-                "source".to_string(),
-                serde_json::Value::String("UserPromptSubmit".to_string()),
+                "session_id".to_string(),
+                serde_json::Value::String(sid.to_string()),
             );
-            if let Some(sid) = session_id {
-                m.insert(
-                    "session_id".to_string(),
-                    serde_json::Value::String(sid.to_string()),
-                );
-            }
-            m
-        },
-        namespace: cwd.map(|s| s.to_string()),
-        session_id: None,
-        content_hash,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-        access_count: 0,
+        }
+        m
     };
+    memory.namespace = cwd.map(|s| s.to_string());
 
     // Use the engine's persist_memory pipeline for consistent indexing
     match codemem_engine::CodememEngine::from_db_path(&db_path) {
@@ -546,43 +533,33 @@ pub(crate) fn cmd_summarize() -> anyhow::Result<()> {
     let mut persist_errors: Vec<String> = Vec::new();
 
     if has_substance && !session_memories.is_empty() {
-        let content_hash = codemem_engine::hooks::content_hash(&summary_text);
-        let now = chrono::Utc::now();
-        let summary_memory = codemem_core::MemoryNode {
-            id: uuid::Uuid::new_v4().to_string(),
-            content: format!("Session summary: {}", summary_text),
-            memory_type: codemem_core::MemoryType::Insight,
-            importance: 0.7,
-            confidence: 1.0,
-            tags: vec!["session-summary".to_string()],
-            metadata: {
-                let mut m = std::collections::HashMap::new();
-                m.insert(
-                    "session_id".to_string(),
-                    serde_json::Value::String(session_id.to_string()),
-                );
-                m.insert(
-                    "files_read".to_string(),
-                    serde_json::json!(files_read.len()),
-                );
-                m.insert(
-                    "files_edited".to_string(),
-                    serde_json::json!(files_edited.len()),
-                );
-                m.insert(
-                    "total_memories".to_string(),
-                    serde_json::json!(session_memories.len()),
-                );
-                m
-            },
-            namespace: namespace.map(|s| s.to_string()),
-            session_id: None,
-            content_hash,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-            access_count: 0,
+        let mut summary_memory = codemem_core::MemoryNode::new(
+            format!("Session summary: {}", summary_text),
+            codemem_core::MemoryType::Insight,
+        );
+        summary_memory.importance = 0.7;
+        summary_memory.tags = vec!["session-summary".to_string()];
+        summary_memory.metadata = {
+            let mut m = std::collections::HashMap::new();
+            m.insert(
+                "session_id".to_string(),
+                serde_json::Value::String(session_id.to_string()),
+            );
+            m.insert(
+                "files_read".to_string(),
+                serde_json::json!(files_read.len()),
+            );
+            m.insert(
+                "files_edited".to_string(),
+                serde_json::json!(files_edited.len()),
+            );
+            m.insert(
+                "total_memories".to_string(),
+                serde_json::json!(session_memories.len()),
+            );
+            m
         };
+        summary_memory.namespace = namespace.map(|s| s.to_string());
         // Use the engine's persist_memory pipeline for consistent indexing
         let result = match &engine {
             Some(eng) => eng.persist_memory(&summary_memory),
@@ -600,33 +577,21 @@ pub(crate) fn cmd_summarize() -> anyhow::Result<()> {
             session_id,
             files_edited.join(", ")
         );
-        let change_hash = codemem_engine::hooks::content_hash(&change_content);
-        let now = chrono::Utc::now();
-        let change_memory = codemem_core::MemoryNode {
-            id: uuid::Uuid::new_v4().to_string(),
-            content: change_content,
-            memory_type: codemem_core::MemoryType::Context,
-            importance: 0.4,
-            confidence: 1.0,
-            tags: vec!["pending-analysis".to_string(), "file-changes".to_string()],
-            metadata: {
-                let mut m = std::collections::HashMap::new();
-                m.insert("session_id".into(), serde_json::json!(session_id));
-                m.insert("files".into(), serde_json::json!(files_edited));
-                m.insert(
-                    "timestamp".into(),
-                    serde_json::json!(chrono::Utc::now().to_rfc3339()),
-                );
-                m
-            },
-            namespace: namespace.map(|s| s.to_string()),
-            session_id: None,
-            content_hash: change_hash,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-            access_count: 0,
+        let mut change_memory =
+            codemem_core::MemoryNode::new(change_content, codemem_core::MemoryType::Context);
+        change_memory.importance = 0.4;
+        change_memory.tags = vec!["pending-analysis".to_string(), "file-changes".to_string()];
+        change_memory.metadata = {
+            let mut m = std::collections::HashMap::new();
+            m.insert("session_id".into(), serde_json::json!(session_id));
+            m.insert("files".into(), serde_json::json!(files_edited));
+            m.insert(
+                "timestamp".into(),
+                serde_json::json!(chrono::Utc::now().to_rfc3339()),
+            );
+            m
         };
+        change_memory.namespace = namespace.map(|s| s.to_string());
         // Use the engine's persist_memory pipeline for consistent indexing
         let result = match &engine {
             Some(eng) => eng.persist_memory(&change_memory),

--- a/crates/codemem/src/cli/tests/commands_consolidation_tests.rs
+++ b/crates/codemem/src/cli/tests/commands_consolidation_tests.rs
@@ -104,23 +104,10 @@ fn consolidate_forget_with_zero_threshold() {
 #[test]
 fn consolidate_forget_deletes_low_importance_memory() {
     let engine = codemem_engine::CodememEngine::for_testing();
-    let now = chrono::Utc::now();
-    let memory = codemem_core::MemoryNode {
-        id: "forget-me".to_string(),
-        content: "low importance throwaway".to_string(),
-        memory_type: codemem_core::MemoryType::Context,
-        importance: 0.05,
-        confidence: 0.5,
-        access_count: 0,
-        content_hash: "hash-forget".to_string(),
-        tags: vec![],
-        metadata: std::collections::HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default("low importance throwaway");
+    memory.id = "forget-me".to_string();
+    memory.importance = 0.05;
+    memory.confidence = 0.5;
     engine.persist_memory(&memory).unwrap();
 
     // Default threshold is 0.1; importance=0.05 < 0.1, access_count=0 → should be deleted
@@ -131,23 +118,11 @@ fn consolidate_forget_deletes_low_importance_memory() {
 #[test]
 fn consolidate_forget_spares_high_importance_memory() {
     let engine = codemem_engine::CodememEngine::for_testing();
-    let now = chrono::Utc::now();
-    let memory = codemem_core::MemoryNode {
-        id: "keep-me".to_string(),
-        content: "important decision about architecture".to_string(),
-        memory_type: codemem_core::MemoryType::Decision,
-        importance: 0.9,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: "hash-keep".to_string(),
-        tags: vec![],
-        metadata: std::collections::HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory =
+        codemem_core::MemoryNode::test_default("important decision about architecture");
+    memory.id = "keep-me".to_string();
+    memory.memory_type = codemem_core::MemoryType::Decision;
+    memory.importance = 0.9;
     engine.persist_memory(&memory).unwrap();
 
     let result = engine.consolidate_forget(None, None, None).unwrap();

--- a/crates/codemem/src/cli/tests/commands_doctor_tests.rs
+++ b/crates/codemem/src/cli/tests/commands_doctor_tests.rs
@@ -49,23 +49,9 @@ fn doctor_storage_stats_on_empty_db() {
 fn doctor_storage_stats_with_data() {
     let storage = codemem_storage::Storage::open_in_memory().unwrap();
 
-    let now = chrono::Utc::now();
-    let memory = codemem_core::MemoryNode {
-        id: "doc-1".to_string(),
-        content: "test memory".to_string(),
-        memory_type: codemem_core::MemoryType::Context,
-        importance: 0.5,
-        confidence: 0.9,
-        access_count: 0,
-        content_hash: "hash".to_string(),
-        tags: vec![],
-        metadata: std::collections::HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default("test memory");
+    memory.id = "doc-1".to_string();
+    memory.confidence = 0.9;
     storage.insert_memory(&memory).unwrap();
 
     let stats = storage.stats().unwrap();

--- a/crates/codemem/src/cli/tests/commands_lifecycle_tests.rs
+++ b/crates/codemem/src/cli/tests/commands_lifecycle_tests.rs
@@ -171,7 +171,6 @@ fn context_with_sessions_and_memories() {
         .unwrap();
 
     // Create Decision and Insight memories that cmd_context looks for
-    let now = chrono::Utc::now();
     for (i, mtype) in [
         codemem_core::MemoryType::Decision,
         codemem_core::MemoryType::Insight,
@@ -181,22 +180,14 @@ fn context_with_sessions_and_memories() {
     .iter()
     .enumerate()
     {
-        let memory = codemem_core::MemoryNode {
-            id: format!("ctx-mem-{i}"),
-            content: format!("memory {i} of type {mtype}"),
-            memory_type: *mtype,
-            importance: 0.7,
-            confidence: 0.9,
-            access_count: 0,
-            content_hash: format!("hash-{i}"),
-            tags: vec!["test".to_string()],
-            metadata: std::collections::HashMap::new(),
-            namespace: Some("myproject".to_string()),
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory =
+            codemem_core::MemoryNode::test_default(&format!("memory {i} of type {mtype}"));
+        memory.id = format!("ctx-mem-{i}");
+        memory.memory_type = *mtype;
+        memory.importance = 0.7;
+        memory.confidence = 0.9;
+        memory.tags = vec!["test".to_string()];
+        memory.namespace = Some("myproject".to_string());
         storage.insert_memory(&memory).unwrap();
     }
 
@@ -232,30 +223,17 @@ fn context_with_sessions_and_memories() {
 fn context_pending_analysis_detection() {
     let storage = codemem_storage::Storage::open_in_memory().unwrap();
 
-    let now = chrono::Utc::now();
-    let memory = codemem_core::MemoryNode {
-        id: "pending-1".to_string(),
-        content: "Files modified in session abc: src/main.rs, src/lib.rs".to_string(),
-        memory_type: codemem_core::MemoryType::Context,
-        importance: 0.4,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: "hash-pending".to_string(),
-        tags: vec!["pending-analysis".to_string(), "file-changes".to_string()],
-        metadata: {
-            let mut m = std::collections::HashMap::new();
-            m.insert(
-                "files".to_string(),
-                serde_json::json!(["src/main.rs", "src/lib.rs"]),
-            );
-            m
-        },
-        namespace: Some("myproject".to_string()),
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default(
+        "Files modified in session abc: src/main.rs, src/lib.rs",
+    );
+    memory.id = "pending-1".to_string();
+    memory.importance = 0.4;
+    memory.tags = vec!["pending-analysis".to_string(), "file-changes".to_string()];
+    memory.metadata.insert(
+        "files".to_string(),
+        serde_json::json!(["src/main.rs", "src/lib.rs"]),
+    );
+    memory.namespace = Some("myproject".to_string());
     storage.insert_memory(&memory).unwrap();
 
     // Verify the pending analysis extraction logic
@@ -284,28 +262,15 @@ fn context_pending_analysis_detection() {
 // ── categorize_memories ─────────────────────────────────────────────
 
 fn make_tool_memory(id: &str, tool: &str, file_path: &str) -> codemem_core::MemoryNode {
-    let now = chrono::Utc::now();
-    let mut metadata = std::collections::HashMap::new();
-    metadata.insert("tool".into(), serde_json::json!(tool));
+    let mut m = codemem_core::MemoryNode::test_default(&format!("{tool} {file_path}"));
+    m.id = id.into();
+    m.importance = 0.3;
+    m.metadata.insert("tool".into(), serde_json::json!(tool));
     if !file_path.is_empty() {
-        metadata.insert("file_path".into(), serde_json::json!(file_path));
+        m.metadata
+            .insert("file_path".into(), serde_json::json!(file_path));
     }
-    codemem_core::MemoryNode {
-        id: id.into(),
-        content: format!("{tool} {file_path}"),
-        memory_type: codemem_core::MemoryType::Context,
-        importance: 0.3,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: format!("h-{id}"),
-        tags: vec![],
-        metadata,
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    }
+    m
 }
 
 #[test]
@@ -347,48 +312,24 @@ fn categorize_memories_glob_tool() {
 
 #[test]
 fn categorize_memories_decisions() {
-    let now = chrono::Utc::now();
-    let memory = codemem_core::MemoryNode {
-        id: "d1".into(),
-        content: "Decided to use Postgres".into(),
-        memory_type: codemem_core::MemoryType::Decision,
-        importance: 0.8,
-        confidence: 0.9,
-        access_count: 0,
-        content_hash: "hd".into(),
-        tags: vec![],
-        metadata: std::collections::HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default("Decided to use Postgres");
+    memory.id = "d1".into();
+    memory.memory_type = codemem_core::MemoryType::Decision;
+    memory.importance = 0.8;
+    memory.confidence = 0.9;
     let cat = categorize_memories(&[memory]);
     assert_eq!(cat.decisions, vec!["Decided to use Postgres"]);
 }
 
 #[test]
 fn categorize_memories_prompts() {
-    let now = chrono::Utc::now();
-    let mut metadata = std::collections::HashMap::new();
-    metadata.insert("source".into(), serde_json::json!("UserPromptSubmit"));
-    let memory = codemem_core::MemoryNode {
-        id: "p1".into(),
-        content: "User prompt: fix the auth bug".into(),
-        memory_type: codemem_core::MemoryType::Context,
-        importance: 0.3,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: "hp".into(),
-        tags: vec!["prompt".to_string()],
-        metadata,
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default("User prompt: fix the auth bug");
+    memory.id = "p1".into();
+    memory.importance = 0.3;
+    memory.tags = vec!["prompt".to_string()];
+    memory
+        .metadata
+        .insert("source".into(), serde_json::json!("UserPromptSubmit"));
     let cat = categorize_memories(&[memory]);
     assert_eq!(cat.prompts, vec!["fix the auth bug"]);
 }
@@ -417,25 +358,16 @@ fn categorize_memories_empty_file_path_skipped() {
 fn categorize_memories_decision_and_prompt_overlap() {
     // A memory that is both Decision type AND has source=UserPromptSubmit
     // should appear in both decisions and prompts.
-    let now = chrono::Utc::now();
-    let mut metadata = std::collections::HashMap::new();
-    metadata.insert("source".into(), serde_json::json!("UserPromptSubmit"));
-    let memory = codemem_core::MemoryNode {
-        id: "overlap".into(),
-        content: "User prompt: decided to use Postgres for persistence".into(),
-        memory_type: codemem_core::MemoryType::Decision,
-        importance: 0.8,
-        confidence: 0.9,
-        access_count: 0,
-        content_hash: "ho".into(),
-        tags: vec![],
-        metadata,
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default(
+        "User prompt: decided to use Postgres for persistence",
+    );
+    memory.id = "overlap".into();
+    memory.memory_type = codemem_core::MemoryType::Decision;
+    memory.importance = 0.8;
+    memory.confidence = 0.9;
+    memory
+        .metadata
+        .insert("source".into(), serde_json::json!("UserPromptSubmit"));
     let cat = categorize_memories(&[memory]);
     assert_eq!(cat.prompts.len(), 1, "should appear as a prompt");
     assert_eq!(cat.decisions.len(), 1, "should also appear as a decision");
@@ -445,26 +377,13 @@ fn categorize_memories_decision_and_prompt_overlap() {
 fn categorize_memories_duplicate_prompts_not_deduped() {
     // Unlike files_read/files_edited/searches, prompts and decisions are not
     // deduplicated. This documents the current behavior.
-    let now = chrono::Utc::now();
     let make_prompt = |id: &str| {
-        let mut metadata = std::collections::HashMap::new();
-        metadata.insert("source".into(), serde_json::json!("UserPromptSubmit"));
-        codemem_core::MemoryNode {
-            id: id.into(),
-            content: "User prompt: fix the bug".into(),
-            memory_type: codemem_core::MemoryType::Context,
-            importance: 0.3,
-            confidence: 1.0,
-            access_count: 0,
-            content_hash: format!("h-{id}"),
-            tags: vec![],
-            metadata,
-            namespace: None,
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        }
+        let mut m = codemem_core::MemoryNode::test_default("User prompt: fix the bug");
+        m.id = id.into();
+        m.importance = 0.3;
+        m.metadata
+            .insert("source".into(), serde_json::json!("UserPromptSubmit"));
+        m
     };
     let memories = vec![make_prompt("p1"), make_prompt("p2")];
     let cat = categorize_memories(&memories);
@@ -476,25 +395,12 @@ fn categorize_memories_duplicate_prompts_not_deduped() {
 fn categorize_memories_prompt_without_prefix() {
     // If content doesn't start with "User prompt: ", strip_prefix returns None
     // and unwrap_or falls back to the full content.
-    let now = chrono::Utc::now();
-    let mut metadata = std::collections::HashMap::new();
-    metadata.insert("source".into(), serde_json::json!("UserPromptSubmit"));
-    let memory = codemem_core::MemoryNode {
-        id: "np".into(),
-        content: "fix the auth module".into(),
-        memory_type: codemem_core::MemoryType::Context,
-        importance: 0.3,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: "hnp".into(),
-        tags: vec![],
-        metadata,
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default("fix the auth module");
+    memory.id = "np".into();
+    memory.importance = 0.3;
+    memory
+        .metadata
+        .insert("source".into(), serde_json::json!("UserPromptSubmit"));
     let cat = categorize_memories(&[memory]);
     assert_eq!(cat.prompts.len(), 1);
     // Full content used since "User prompt: " prefix is absent
@@ -503,26 +409,13 @@ fn categorize_memories_prompt_without_prefix() {
 
 #[test]
 fn categorize_memories_truncates_long_prompt() {
-    let now = chrono::Utc::now();
     let long_prompt = "x".repeat(200);
-    let mut metadata = std::collections::HashMap::new();
-    metadata.insert("source".into(), serde_json::json!("UserPromptSubmit"));
-    let memory = codemem_core::MemoryNode {
-        id: "lp".into(),
-        content: format!("User prompt: {long_prompt}"),
-        memory_type: codemem_core::MemoryType::Context,
-        importance: 0.3,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: "hlp".into(),
-        tags: vec![],
-        metadata,
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default(&format!("User prompt: {long_prompt}"));
+    memory.id = "lp".into();
+    memory.importance = 0.3;
+    memory
+        .metadata
+        .insert("source".into(), serde_json::json!("UserPromptSubmit"));
     let cat = categorize_memories(&[memory]);
     assert_eq!(cat.prompts.len(), 1);
     // truncate_str(text, 120) should truncate and append "..."
@@ -532,24 +425,12 @@ fn categorize_memories_truncates_long_prompt() {
 
 #[test]
 fn categorize_memories_truncates_long_decision() {
-    let now = chrono::Utc::now();
     let long_decision = "d".repeat(200);
-    let memory = codemem_core::MemoryNode {
-        id: "ld".into(),
-        content: long_decision,
-        memory_type: codemem_core::MemoryType::Decision,
-        importance: 0.8,
-        confidence: 0.9,
-        access_count: 0,
-        content_hash: "hld".into(),
-        tags: vec![],
-        metadata: std::collections::HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = codemem_core::MemoryNode::test_default(&long_decision);
+    memory.id = "ld".into();
+    memory.memory_type = codemem_core::MemoryType::Decision;
+    memory.importance = 0.8;
+    memory.confidence = 0.9;
     let cat = categorize_memories(&[memory]);
     assert_eq!(cat.decisions.len(), 1);
     assert!(cat.decisions[0].len() <= 123);

--- a/crates/codemem/src/lib.rs
+++ b/crates/codemem/src/lib.rs
@@ -2,14 +2,4 @@ pub mod api;
 pub mod cli;
 pub mod mcp;
 
-pub(crate) fn truncate_str(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        let mut end = max;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        format!("{}...", &s[..end])
-    }
-}
+pub(crate) use codemem_core::truncate as truncate_str;

--- a/crates/codemem/src/mcp/tests/tools_consolidation_tests.rs
+++ b/crates/codemem/src/mcp/tests/tools_consolidation_tests.rs
@@ -1,8 +1,6 @@
 use super::*;
 use crate::mcp::test_helpers::*;
 use codemem_core::{MemoryNode, MemoryType, VectorBackend};
-use codemem_storage::Storage;
-use std::collections::HashMap;
 
 /// Helper: call a tool and return the result Value.
 fn call_tool(server: &McpServer, tool_name: &str, arguments: Value) -> Value {
@@ -50,27 +48,13 @@ fn consolidate_decay_reduces_importance() {
     let server = test_server();
 
     // Store a memory with known importance
-    let now = chrono::Utc::now();
-    let sixty_days_ago = now - chrono::Duration::days(60);
-    let id = uuid::Uuid::new_v4().to_string();
-    let content = "old memory that should decay";
-    let hash = Storage::content_hash(content);
-    let memory = MemoryNode {
-        id: id.clone(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.8,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: hash,
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: sixty_days_ago,
-        updated_at: sixty_days_ago,
-        last_accessed_at: sixty_days_ago,
-    };
+    let sixty_days_ago = chrono::Utc::now() - chrono::Duration::days(60);
+    let mut memory = MemoryNode::test_default("old memory that should decay");
+    memory.importance = 0.8;
+    memory.created_at = sixty_days_ago;
+    memory.updated_at = sixty_days_ago;
+    memory.last_accessed_at = sixty_days_ago;
+    let id = memory.id.clone();
     server.engine.storage().insert_memory(&memory).unwrap();
 
     // Run decay with default threshold (30 days)
@@ -190,26 +174,8 @@ fn consolidate_forget_deletes_low_importance() {
     let server = test_server();
 
     // Store a memory with very low importance and zero access count
-    let now = chrono::Utc::now();
-    let id = uuid::Uuid::new_v4().to_string();
-    let content = "forgettable memory";
-    let hash = Storage::content_hash(content);
-    let memory = MemoryNode {
-        id: id.clone(),
-        content: content.to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.05,
-        confidence: 1.0,
-        access_count: 0,
-        content_hash: hash,
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = MemoryNode::test_default("forgettable memory");
+    memory.importance = 0.05;
     server.engine.storage().insert_memory(&memory).unwrap();
 
     // Verify it exists
@@ -235,23 +201,9 @@ fn consolidate_forget_keeps_accessed_memories() {
     let server = test_server();
 
     // Store a memory with low importance but nonzero access count directly
-    let now = chrono::Utc::now();
-    let memory = MemoryNode {
-        id: uuid::Uuid::new_v4().to_string(),
-        content: "low importance but accessed".to_string(),
-        memory_type: MemoryType::Context,
-        importance: 0.05,
-        confidence: 1.0,
-        access_count: 5,
-        content_hash: Storage::content_hash("low importance but accessed"),
-        tags: vec![],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = MemoryNode::test_default("low importance but accessed");
+    memory.importance = 0.05;
+    memory.access_count = 5;
     server.engine.storage().insert_memory(&memory).unwrap();
 
     // This memory has access_count = 5, so it should NOT be forgotten
@@ -289,26 +241,9 @@ fn consolidate_forget_custom_threshold() {
     let server = test_server();
 
     // Store two memories with different importance
-    let now = chrono::Utc::now();
     for (imp, content) in [(0.3, "medium importance"), (0.05, "very low importance")] {
-        let id = uuid::Uuid::new_v4().to_string();
-        let hash = Storage::content_hash(content);
-        let memory = MemoryNode {
-            id,
-            content: content.to_string(),
-            memory_type: MemoryType::Context,
-            importance: imp,
-            confidence: 1.0,
-            access_count: 0,
-            content_hash: hash,
-            tags: vec![],
-            metadata: HashMap::new(),
-            namespace: None,
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::test_default(content);
+        memory.importance = imp;
         server.engine.storage().insert_memory(&memory).unwrap();
     }
 
@@ -510,7 +445,6 @@ fn consolidate_forget_with_target_tags() {
     let server = test_server();
 
     // Store two low-importance memories: one with static-analysis tag, one without
-    let now = chrono::Utc::now();
     for (content, tags) in [
         (
             "enrichment noise about coupling",
@@ -518,24 +452,11 @@ fn consolidate_forget_with_target_tags() {
         ),
         ("important manual insight", vec!["manual".to_string()]),
     ] {
-        let id = uuid::Uuid::new_v4().to_string();
-        let hash = Storage::content_hash(content);
-        let memory = MemoryNode {
-            id,
-            content: content.to_string(),
-            memory_type: MemoryType::Insight,
-            importance: 0.3,
-            confidence: 0.5,
-            access_count: 0,
-            content_hash: hash,
-            tags,
-            metadata: HashMap::new(),
-            namespace: None,
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::test_default(content);
+        memory.memory_type = MemoryType::Insight;
+        memory.importance = 0.3;
+        memory.confidence = 0.5;
+        memory.tags = tags;
         server.engine.storage().insert_memory(&memory).unwrap();
     }
 
@@ -564,30 +485,17 @@ fn consolidate_forget_with_target_tags() {
 fn consolidate_forget_with_max_access_count() {
     let server = test_server();
 
-    let now = chrono::Utc::now();
     // Store two static-analysis memories: one never accessed, one accessed twice
     for (content, access_count) in [
         ("never accessed enrichment insight", 0u32),
         ("twice accessed enrichment insight", 2u32),
     ] {
-        let id = uuid::Uuid::new_v4().to_string();
-        let hash = Storage::content_hash(content);
-        let memory = MemoryNode {
-            id,
-            content: content.to_string(),
-            memory_type: MemoryType::Insight,
-            importance: 0.3,
-            confidence: 0.5,
-            access_count,
-            content_hash: hash,
-            tags: vec!["static-analysis".to_string()],
-            metadata: HashMap::new(),
-            namespace: None,
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::test_default(content);
+        memory.memory_type = MemoryType::Insight;
+        memory.importance = 0.3;
+        memory.confidence = 0.5;
+        memory.access_count = access_count;
+        memory.tags = vec!["static-analysis".to_string()];
         server.engine.storage().insert_memory(&memory).unwrap();
     }
 

--- a/crates/codemem/src/mcp/tests/tools_memory_crud_tests.rs
+++ b/crates/codemem/src/mcp/tests/tools_memory_crud_tests.rs
@@ -145,30 +145,16 @@ fn recall_filters_by_namespace() {
     let server = test_server();
 
     // Store memories with different namespaces via direct storage
-    let now = chrono::Utc::now();
     for (content, ns) in [
         ("rust ownership in project-a", Some("/projects/a")),
         ("rust borrowing in project-b", Some("/projects/b")),
         ("rust global memory no namespace", None),
     ] {
-        let id = uuid::Uuid::new_v4().to_string();
-        let hash = Storage::content_hash(content);
-        let memory = MemoryNode {
-            id: id.clone(),
-            content: content.to_string(),
-            memory_type: MemoryType::Insight,
-            importance: 0.5,
-            confidence: 1.0,
-            access_count: 0,
-            content_hash: hash,
-            tags: vec!["rust".to_string()],
-            metadata: HashMap::new(),
-            namespace: ns.map(String::from),
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::test_default(content);
+        memory.memory_type = MemoryType::Insight;
+        memory.tags = vec!["rust".to_string()];
+        memory.namespace = ns.map(String::from);
+        let id = memory.id.clone();
         server.engine.storage().insert_memory(&memory).unwrap();
 
         // Add graph node so graph scoring works

--- a/crates/codemem/src/mcp/tests/tools_memory_quality_tests.rs
+++ b/crates/codemem/src/mcp/tests/tools_memory_quality_tests.rs
@@ -13,25 +13,11 @@ fn recall_with_exclude_tags_filters_out() {
     store_memory(&server, "rust ownership rules", "insight", &["rust"]);
 
     // Store one with static-analysis tag directly
-    let now = chrono::Utc::now();
-    let id = uuid::Uuid::new_v4().to_string();
-    let hash = Storage::content_hash("rust auto-generated analysis");
-    let memory = MemoryNode {
-        id: id.clone(),
-        content: "rust auto-generated analysis".to_string(),
-        memory_type: MemoryType::Insight,
-        importance: 0.5,
-        confidence: 0.5,
-        access_count: 0,
-        content_hash: hash,
-        tags: vec!["rust".to_string(), "static-analysis".to_string()],
-        metadata: HashMap::new(),
-        namespace: None,
-        session_id: None,
-        created_at: now,
-        updated_at: now,
-        last_accessed_at: now,
-    };
+    let mut memory = MemoryNode::test_default("rust auto-generated analysis");
+    memory.memory_type = MemoryType::Insight;
+    memory.confidence = 0.5;
+    memory.tags = vec!["rust".to_string(), "static-analysis".to_string()];
+    let id = memory.id.clone();
     server.engine.storage().insert_memory(&memory).unwrap();
     server
         .engine
@@ -71,29 +57,15 @@ fn recall_with_min_importance_filters() {
     let server = test_server();
 
     // Store two memories with different importance
-    let now = chrono::Utc::now();
     for (content, importance) in [
         ("rust high importance memory", 0.8),
         ("rust low importance memory", 0.2),
     ] {
-        let id = uuid::Uuid::new_v4().to_string();
-        let hash = Storage::content_hash(content);
-        let memory = MemoryNode {
-            id: id.clone(),
-            content: content.to_string(),
-            memory_type: MemoryType::Insight,
-            importance,
-            confidence: 1.0,
-            access_count: 0,
-            content_hash: hash,
-            tags: vec!["rust".to_string()],
-            metadata: HashMap::new(),
-            namespace: None,
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::test_default(content);
+        memory.memory_type = MemoryType::Insight;
+        memory.importance = importance;
+        memory.tags = vec!["rust".to_string()];
+        let id = memory.id.clone();
         server.engine.storage().insert_memory(&memory).unwrap();
         server
             .engine
@@ -285,26 +257,12 @@ fn recall_public_api_with_min_confidence() {
 
     // Store directly with controlled confidence, including graph nodes
     // so that the scoring threshold (> 0.01) is met.
-    let now = chrono::Utc::now();
     for (content, confidence) in [("confidence test high", 0.9), ("confidence test low", 0.1)] {
-        let id = uuid::Uuid::new_v4().to_string();
-        let hash = Storage::content_hash(content);
-        let memory = MemoryNode {
-            id: id.clone(),
-            content: content.to_string(),
-            memory_type: MemoryType::Insight,
-            importance: 0.5,
-            confidence,
-            access_count: 0,
-            content_hash: hash,
-            tags: vec!["conf".to_string()],
-            metadata: HashMap::new(),
-            namespace: None,
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = MemoryNode::test_default(content);
+        memory.memory_type = MemoryType::Insight;
+        memory.confidence = confidence;
+        memory.tags = vec!["conf".to_string()];
+        let id = memory.id.clone();
         server.engine.storage().insert_memory(&memory).unwrap();
         server
             .engine

--- a/crates/codemem/src/mcp/tools_memory.rs
+++ b/crates/codemem/src/mcp/tools_memory.rs
@@ -6,7 +6,6 @@ use super::types::ToolResult;
 use super::McpServer;
 use codemem_core::{CodememError, Edge, GraphBackend, MemoryType, RelationshipType};
 use codemem_engine::SplitPart;
-use codemem_storage::Storage;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
@@ -25,26 +24,11 @@ impl McpServer {
         let tags = parse_string_array(args, "tags");
         let namespace = parse_opt_string(args, "namespace");
 
-        let now = chrono::Utc::now();
-        let id = uuid::Uuid::new_v4().to_string();
-        let hash = Storage::content_hash(content);
-
-        let memory = codemem_core::MemoryNode {
-            id: id.clone(),
-            content: content.to_string(),
-            memory_type,
-            importance,
-            confidence: 1.0,
-            access_count: 0,
-            content_hash: hash,
-            tags,
-            metadata: HashMap::new(),
-            namespace,
-            session_id: None,
-            created_at: now,
-            updated_at: now,
-            last_accessed_at: now,
-        };
+        let mut memory = codemem_core::MemoryNode::new(content, memory_type);
+        let id = memory.id.clone();
+        memory.importance = importance;
+        memory.tags = tags;
+        memory.namespace = namespace;
 
         match self.engine.persist_memory(&memory) {
             Ok(()) => {}
@@ -60,6 +44,7 @@ impl McpServer {
                 Ok(g) => g,
                 Err(e) => return ToolResult::tool_error(format!("Lock error: {e}")),
             };
+            let now = chrono::Utc::now();
             for link_val in links {
                 if let Some(link_id) = link_val.as_str() {
                     let edge = Edge {


### PR DESCRIPTION
## Summary
- **MemoryNode::new() + test_default()**: Auto-generates id, content_hash, timestamps. Replaces 63 struct literals across 29 files
- **MapStorageErr trait**: `.storage_err()` extension replaces 182 verbose `.map_err(|e| CodememError::Storage(e.to_string()))` calls across 6 storage files
- **Canonical truncate in codemem-core::utils**: Single implementation, re-exported from scoring.rs and codemem lib — removes 2 duplicate implementations
- **insert_memory_inner() helper**: Extracts shared dedup+INSERT logic from `insert_memory` and `insert_memory_no_tx`
- **store_enrichment_memory()**: Merges `store_insight` and `store_pattern_memory` (~80% code dedup)
- **test_default() builder**: ~20 test files converted from verbose struct literals

Net: 40 files changed, -799 lines

## Test plan
- [x] `cargo build --workspace` — compiles clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all 702 tests pass
- [x] `cargo fmt --all -- --check` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)