### PR TITLE
fix: gate release jobs on releases_created == 'true'

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     name: Build (${{ matrix.name }})
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     strategy:
       matrix:
         include:
@@ -104,7 +104,7 @@ jobs:
   upload-release-artifacts:
     name: Upload Release Artifacts
     needs: [release-please, build]
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -122,7 +122,7 @@ jobs:
   publish:
     name: Publish to crates.io
     needs: [release-please, build]
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -175,7 +175,7 @@ jobs:
   homebrew:
     name: Update Homebrew Tap
     needs: [release-please, upload-release-artifacts]
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- Downstream jobs (build, upload, publish, homebrew) use bare truthy check on `releases_created` which passes even when no release is created
- Changed to explicit `== 'true'` comparison on all 4 downstream jobs

## Test plan
- [ ] Merge to main → verify build/publish/homebrew jobs are skipped (no release pending)
- [ ] Once verified, re-run debug pipeline from #22849138930 to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)