### PR TITLE
fix: use directory basename as namespace instead of full path

### DIFF
--- a/crates/codemem/src/cli/commands_data.rs
+++ b/crates/codemem/src/cli/commands_data.rs
@@ -180,10 +180,10 @@ pub(crate) fn cmd_ingest() -> anyhow::Result<()> {
                 (extracted.content.clone(), false)
             };
 
-        // Use current working directory as namespace
+        // Use directory basename as namespace (not full path)
         let namespace = std::env::current_dir()
             .ok()
-            .map(|p| p.to_string_lossy().to_string());
+            .map(|p| super::namespace_from_path(&p.to_string_lossy()).to_string());
 
         let mut memory = codemem_core::MemoryNode::new(content.clone(), extracted.memory_type);
         let id = memory.id.clone();
@@ -645,7 +645,7 @@ fn flush_batch(
     memory.importance = importance;
     memory.tags = tags;
     memory.metadata = metadata;
-    memory.namespace = Some(watch_dir.to_string_lossy().to_string());
+    memory.namespace = Some(super::namespace_from_path(&watch_dir.to_string_lossy()).to_string());
 
     match engine.persist_memory(&memory) {
         Ok(()) => {

--- a/crates/codemem/src/cli/commands_lifecycle.rs
+++ b/crates/codemem/src/cli/commands_lifecycle.rs
@@ -2,13 +2,11 @@
 
 use codemem_core::StorageBackend;
 
-/// Derive a short namespace from a working-directory path.
-/// Returns the directory basename (e.g. `/Users/me/project` → `"project"`).
+use super::namespace_from_path;
+
+/// Alias for backwards compatibility within this module.
 fn namespace_from_cwd(cwd: &str) -> &str {
-    std::path::Path::new(cwd)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or(cwd)
+    namespace_from_path(cwd)
 }
 
 // ── Sessions Commands ─────────────────────────────────────────────────────

--- a/crates/codemem/src/cli/mod.rs
+++ b/crates/codemem/src/cli/mod.rs
@@ -370,6 +370,15 @@ pub fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Derive a short namespace from a working-directory path.
+/// Returns the directory basename (e.g. `/Users/me/project` → `"project"`).
+pub(crate) fn namespace_from_path(path: &str) -> &str {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(path)
+}
+
 /// Return the system-wide Codemem database path: ~/.codemem/codemem.db
 pub(crate) fn codemem_db_path() -> PathBuf {
     dirs::home_dir()


### PR DESCRIPTION
## Summary
- `cmd_ingest` and file watcher were using full filesystem path (e.g. `/Users/me/Documents/project`) as namespace
- Now uses directory basename (`project`) matching how `cmd_analyze` and lifecycle hooks already work
- Extracted `namespace_from_path()` to shared `cli/mod.rs`

## Test plan
- [x] All 5 `namespace_from_cwd` tests pass
- [x] Zero clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)