### PR TITLE
fix: namespace-scoped file hashes, configurable embed batch size, hook storage

### DIFF
--- a/crates/codemem-core/src/traits.rs
+++ b/crates/codemem-core/src/traits.rs
@@ -482,11 +482,16 @@ pub trait StorageBackend: Send + Sync {
 
     // ── File Hash Tracking ──────────────────────────────────────────
 
-    /// Load all file hashes for incremental indexing. Returns path -> hash map.
-    fn load_file_hashes(&self) -> Result<HashMap<String, String>, CodememError>;
+    /// Load file hashes for incremental indexing, scoped to a namespace.
+    /// Returns path -> hash map.
+    fn load_file_hashes(&self, namespace: &str) -> Result<HashMap<String, String>, CodememError>;
 
-    /// Save file hashes for incremental indexing.
-    fn save_file_hashes(&self, hashes: &HashMap<String, String>) -> Result<(), CodememError>;
+    /// Save file hashes for incremental indexing, scoped to a namespace.
+    fn save_file_hashes(
+        &self,
+        namespace: &str,
+        hashes: &HashMap<String, String>,
+    ) -> Result<(), CodememError>;
 
     // ── Session Activity Tracking ─────────────────────────────────
 

--- a/crates/codemem-engine/src/file_indexing.rs
+++ b/crates/codemem-engine/src/file_indexing.rs
@@ -136,9 +136,10 @@ impl CodememEngine {
                 .change_detector
                 .lock()
                 .map_err(|_| CodememError::LockPoisoned("change_detector".into()))?;
+            let ns = namespace.unwrap_or("");
             let cd = cd_guard.get_or_insert_with(|| {
                 let mut cd = index::incremental::ChangeDetector::new();
-                cd.load_from_storage(&*self.storage);
+                cd.load_from_storage(&*self.storage, ns);
                 cd
             });
             let (changed, hash) = cd.check_changed(&path_str, &content);
@@ -191,7 +192,7 @@ impl CodememEngine {
         if let Ok(mut cd_guard) = self.change_detector.lock() {
             if let Some(cd) = cd_guard.as_mut() {
                 cd.record_hash(&path_str, hash);
-                if let Err(e) = cd.save_to_storage(&*self.storage) {
+                if let Err(e) = cd.save_to_storage(&*self.storage, namespace.unwrap_or("")) {
                     tracing::warn!("Failed to save file hash for {path_str}: {e}");
                 }
             }
@@ -566,7 +567,9 @@ impl CodememEngine {
         self.save_index();
 
         // Save incremental state
-        indexer.change_detector().save_to_storage(self.storage())?;
+        indexer
+            .change_detector()
+            .save_to_storage(self.storage(), options.namespace)?;
 
         Ok(AnalyzeResult {
             files_parsed: resolved.index.files_parsed,

--- a/crates/codemem-engine/src/index/incremental.rs
+++ b/crates/codemem-engine/src/index/incremental.rs
@@ -24,8 +24,12 @@ impl ChangeDetector {
     ///
     /// This reads from the `file_hashes` table if it exists. If the table
     /// doesn't exist or the query fails, starts fresh with no known hashes.
-    pub fn load_from_storage(&mut self, storage: &dyn codemem_core::StorageBackend) {
-        match storage.load_file_hashes() {
+    pub fn load_from_storage(
+        &mut self,
+        storage: &dyn codemem_core::StorageBackend,
+        namespace: &str,
+    ) {
+        match storage.load_file_hashes(namespace) {
             Ok(hashes) => {
                 tracing::debug!("Loaded {} known file hashes", hashes.len());
                 self.known_hashes = hashes;
@@ -40,8 +44,9 @@ impl ChangeDetector {
     pub fn save_to_storage(
         &self,
         storage: &dyn codemem_core::StorageBackend,
+        namespace: &str,
     ) -> Result<(), codemem_core::CodememError> {
-        storage.save_file_hashes(&self.known_hashes)
+        storage.save_file_hashes(namespace, &self.known_hashes)
     }
 
     /// Check if a file has changed and return (changed, hash) to avoid double-hashing.

--- a/crates/codemem-engine/src/persistence/mod.rs
+++ b/crates/codemem-engine/src/persistence/mod.rs
@@ -606,14 +606,14 @@ impl super::CodememEngine {
             .collect();
 
         // Phase 2+3: Embed in batches and persist progressively.
-        const EMBED_CHUNK_SIZE: usize = 64;
+        let embed_batch_size = self.config.embedding.batch_size;
 
         let all_pairs: Vec<(String, String)> = sym_texts.into_iter().chain(chunk_texts).collect();
         let total = all_pairs.len();
         let sym_count = symbols.len();
         let mut done = 0usize;
 
-        for batch in all_pairs.chunks(EMBED_CHUNK_SIZE) {
+        for batch in all_pairs.chunks(embed_batch_size) {
             let texts: Vec<&str> = batch.iter().map(|(_, t)| t.as_str()).collect();
 
             let t0 = std::time::Instant::now();

--- a/crates/codemem-storage/src/backend.rs
+++ b/crates/codemem-storage/src/backend.rs
@@ -367,14 +367,14 @@ impl StorageBackend for Storage {
         Ok(())
     }
 
-    fn load_file_hashes(&self) -> Result<HashMap<String, String>, CodememError> {
+    fn load_file_hashes(&self, namespace: &str) -> Result<HashMap<String, String>, CodememError> {
         let conn = self.conn()?;
         let mut stmt = conn
-            .prepare("SELECT file_path, content_hash FROM file_hashes")
+            .prepare("SELECT file_path, content_hash FROM file_hashes WHERE namespace = ?1")
             .storage_err()?;
 
         let rows = stmt
-            .query_map([], |row| {
+            .query_map(params![namespace], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })
             .storage_err()?
@@ -384,16 +384,24 @@ impl StorageBackend for Storage {
         Ok(rows.into_iter().collect())
     }
 
-    fn save_file_hashes(&self, hashes: &HashMap<String, String>) -> Result<(), CodememError> {
+    fn save_file_hashes(
+        &self,
+        namespace: &str,
+        hashes: &HashMap<String, String>,
+    ) -> Result<(), CodememError> {
         let conn = self.conn()?;
         let tx = conn.unchecked_transaction().storage_err()?;
 
-        tx.execute("DELETE FROM file_hashes", []).storage_err()?;
+        tx.execute(
+            "DELETE FROM file_hashes WHERE namespace = ?1",
+            params![namespace],
+        )
+        .storage_err()?;
 
         for (path, hash) in hashes {
             tx.execute(
-                "INSERT INTO file_hashes (file_path, content_hash) VALUES (?1, ?2)",
-                params![path, hash],
+                "INSERT INTO file_hashes (namespace, file_path, content_hash) VALUES (?1, ?2, ?3)",
+                params![namespace, path, hash],
             )
             .storage_err()?;
         }

--- a/crates/codemem-storage/src/migrations.rs
+++ b/crates/codemem-storage/src/migrations.rs
@@ -59,6 +59,11 @@ const MIGRATIONS: &[Migration] = &[
         description: "Separate api_client_calls table",
         sql: include_str!("migrations/010_api_client_calls.sql"),
     },
+    Migration {
+        version: 11,
+        description: "Namespace-scoped file hashes",
+        sql: include_str!("migrations/011_namespace_scoped_file_hashes.sql"),
+    },
 ];
 
 /// Run all pending migrations on the given connection.

--- a/crates/codemem-storage/src/migrations/011_namespace_scoped_file_hashes.sql
+++ b/crates/codemem-storage/src/migrations/011_namespace_scoped_file_hashes.sql
@@ -1,0 +1,16 @@
+-- Scope file_hashes by namespace so different repos don't collide.
+-- Recreate the table with (namespace, file_path) as the composite primary key.
+
+CREATE TABLE IF NOT EXISTS file_hashes_new (
+    namespace TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    PRIMARY KEY (namespace, file_path)
+);
+
+-- Migrate existing data with empty namespace (preserves hashes for single-repo setups)
+INSERT OR IGNORE INTO file_hashes_new (namespace, file_path, content_hash)
+    SELECT '', file_path, content_hash FROM file_hashes;
+
+DROP TABLE IF EXISTS file_hashes;
+ALTER TABLE file_hashes_new RENAME TO file_hashes;

--- a/crates/codemem-storage/src/tests/backend_tests.rs
+++ b/crates/codemem-storage/src/tests/backend_tests.rs
@@ -54,8 +54,8 @@ fn file_hashes_roundtrip() {
     hashes.insert("src/main.rs".to_string(), "abc123".to_string());
     hashes.insert("src/lib.rs".to_string(), "def456".to_string());
 
-    backend.save_file_hashes(&hashes).unwrap();
-    let loaded = backend.load_file_hashes().unwrap();
+    backend.save_file_hashes("test-ns", &hashes).unwrap();
+    let loaded = backend.load_file_hashes("test-ns").unwrap();
     assert_eq!(loaded.len(), 2);
     assert_eq!(loaded.get("src/main.rs"), Some(&"abc123".to_string()));
 }

--- a/crates/codemem/src/cli/commands_analyze.rs
+++ b/crates/codemem/src/cli/commands_analyze.rs
@@ -19,7 +19,7 @@ pub(crate) fn cmd_analyze(root: &Path, namespace: Option<&str>, days: u64) -> an
 
     // Load incremental state
     let mut change_detector = codemem_engine::index::incremental::ChangeDetector::new();
-    change_detector.load_from_storage(engine.storage());
+    change_detector.load_from_storage(engine.storage(), ns);
 
     println!("Analyzing {}...", root.display());
 

--- a/crates/codemem/src/cli/commands_export.rs
+++ b/crates/codemem/src/cli/commands_export.rs
@@ -313,9 +313,15 @@ pub(crate) fn cmd_index(root: &std::path::Path, verbose: bool) -> anyhow::Result
     let db_path = super::codemem_db_path();
     let engine = codemem_engine::CodememEngine::from_db_path(&db_path)?;
 
-    // Load incremental state
+    // Derive namespace early so we can scope file hashes
+    let ns = root
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or_else(|| root.to_str().unwrap_or("unknown"));
+
+    // Load incremental state scoped to this namespace
     let mut change_detector = codemem_engine::index::incremental::ChangeDetector::new();
-    change_detector.load_from_storage(engine.storage());
+    change_detector.load_from_storage(engine.storage(), ns);
 
     let mut indexer = codemem_engine::Indexer::with_change_detector(change_detector);
 
@@ -429,8 +435,9 @@ pub(crate) fn cmd_index(root: &std::path::Path, verbose: bool) -> anyhow::Result
             })
             .collect();
 
+        let batch_size = engine.config().embedding.batch_size;
         let mut all_sym_pairs: Vec<(String, Vec<f32>)> = Vec::new();
-        for (batch_idx, chunk) in embed_data.chunks(32).enumerate() {
+        for (batch_idx, chunk) in embed_data.chunks(batch_size).enumerate() {
             let texts: Vec<&str> = chunk.iter().map(|(_, t)| t.as_str()).collect();
             if let Ok(embeddings) = emb_guard.embed_batch(&texts) {
                 for ((sym_id, _), embedding) in chunk.iter().zip(embeddings) {
@@ -441,7 +448,7 @@ pub(crate) fn cmd_index(root: &std::path::Path, verbose: bool) -> anyhow::Result
                     symbols_embedded += 1;
                 }
             }
-            let done = (batch_idx + 1) * 32;
+            let done = (batch_idx + 1) * batch_size;
             print!("\r  Embedding symbols: {}/{}", done.min(total), total);
             std::io::Write::flush(&mut std::io::stdout()).ok();
         }
@@ -464,7 +471,7 @@ pub(crate) fn cmd_index(root: &std::path::Path, verbose: bool) -> anyhow::Result
     // Save incremental state
     indexer
         .change_detector()
-        .save_to_storage(engine.storage())?;
+        .save_to_storage(engine.storage(), ns)?;
 
     if verbose {
         println!("\nSymbols:");

--- a/crates/codemem/src/cli/commands_init.rs
+++ b/crates/codemem/src/cli/commands_init.rs
@@ -589,9 +589,10 @@ pub(crate) fn batch_embed_existing(db_path: &std::path::Path) {
 
     let mut embedded = 0usize;
     let total = rows.len();
+    let batch_size = config.embedding.batch_size;
 
     let mut all_pairs: Vec<(String, Vec<f32>)> = Vec::new();
-    for (batch_idx, chunk) in rows.chunks(32).enumerate() {
+    for (batch_idx, chunk) in rows.chunks(batch_size).enumerate() {
         let texts: Vec<&str> = chunk.iter().map(|(_, content)| content.as_str()).collect();
         if let Ok(embeddings) = emb_service.embed_batch(&texts) {
             for ((id, _), embedding) in chunk.iter().zip(embeddings) {
@@ -600,7 +601,7 @@ pub(crate) fn batch_embed_existing(db_path: &std::path::Path) {
                 embedded += 1;
             }
         }
-        let done = (batch_idx + 1) * 32;
+        let done = (batch_idx + 1) * batch_size;
         print!("\r  Embedding: {}/{}", done.min(total), total);
         std::io::Write::flush(&mut std::io::stdout()).ok();
     }

--- a/crates/codemem/src/cli/mod.rs
+++ b/crates/codemem/src/cli/mod.rs
@@ -359,7 +359,7 @@ pub fn run() -> anyhow::Result<()> {
         Commands::Context => {
             // H3: Open lightweight storage instead of the full engine.
             let db_path = codemem_db_path();
-            match codemem_engine::Storage::open(&db_path) {
+            match codemem_engine::Storage::open_without_migrations(&db_path) {
                 Ok(storage) => {
                     commands_lifecycle::cmd_context(&storage)?;
                 }


### PR DESCRIPTION
## Summary
- **Namespace-scoped file hashes**: Migration 011 adds `namespace` column to `file_hashes` table so incremental indexing doesn't skip files when indexing different repos with overlapping relative paths (e.g. `src/main.rs`)
- **Configurable embed batch size**: Replace hardcoded batch sizes (32/64) in `commands_init`, `commands_export`, and `persist_index_results` with `config.embedding.batch_size`
- **Hook storage fix**: Use `open_without_migrations` for the `SessionStart` hook (`codemem context`) to match all other hook handlers and avoid failures after `/compact`

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Verify `codemem analyze` on two different repos indexes both fully (no skipped files)
- [ ] Verify `/compact` no longer shows `SessionStart:compact hook error`
- [ ] Verify custom `batch_size` in `~/.codemem/config.toml` is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)