### PR TITLE
feat: graph accuracy improvements and cross-service API surface detection

### DIFF
--- a/crates/codemem-core/src/traits.rs
+++ b/crates/codemem-core/src/traits.rs
@@ -865,4 +865,45 @@ pub trait StorageBackend: Send + Sync {
     ) -> Result<Vec<(String, String, String, String)>, CodememError> {
         Ok(Vec::new())
     }
+
+    /// Store a detected event channel.
+    fn store_event_channel(
+        &self,
+        channel: &str,
+        direction: &str,
+        protocol: &str,
+        handler: &str,
+        namespace: &str,
+        description: &str,
+    ) -> Result<(), CodememError> {
+        let _ = (
+            channel,
+            direction,
+            protocol,
+            handler,
+            namespace,
+            description,
+        );
+        Ok(())
+    }
+
+    /// List event channels for a namespace.
+    /// Returns (channel, direction, protocol, handler, description) tuples.
+    #[allow(clippy::type_complexity)]
+    fn list_event_channels(
+        &self,
+        namespace: &str,
+    ) -> Result<Vec<(String, String, String, String, String)>, CodememError> {
+        let _ = namespace;
+        Ok(Vec::new())
+    }
+
+    /// List all event channels across all namespaces.
+    /// Returns (channel, direction, protocol, handler, namespace, description) tuples.
+    #[allow(clippy::type_complexity)]
+    fn list_all_event_channels(
+        &self,
+    ) -> Result<Vec<(String, String, String, String, String, String)>, CodememError> {
+        Ok(Vec::new())
+    }
 }

--- a/crates/codemem-core/src/types.rs
+++ b/crates/codemem-core/src/types.rs
@@ -121,6 +121,13 @@ pub enum RelationshipType {
     Writes,
     /// Method → parent method (virtual dispatch) — derived from SCIP `is_implementation` on methods.
     Overrides,
+    // Cross-service relationships (API surface detection)
+    /// Service A's HTTP client call targets Service B's endpoint.
+    HttpCalls,
+    /// Producer publishes to an event channel/topic.
+    PublishesTo,
+    /// Consumer subscribes to an event channel/topic.
+    SubscribesTo,
 }
 
 impl std::fmt::Display for RelationshipType {
@@ -154,6 +161,9 @@ impl std::fmt::Display for RelationshipType {
             Self::Reads => write!(f, "READS"),
             Self::Writes => write!(f, "WRITES"),
             Self::Overrides => write!(f, "OVERRIDES"),
+            Self::HttpCalls => write!(f, "HTTP_CALLS"),
+            Self::PublishesTo => write!(f, "PUBLISHES_TO"),
+            Self::SubscribesTo => write!(f, "SUBSCRIBES_TO"),
         }
     }
 }
@@ -191,6 +201,9 @@ impl std::str::FromStr for RelationshipType {
             "READS" => Ok(Self::Reads),
             "WRITES" => Ok(Self::Writes),
             "OVERRIDES" => Ok(Self::Overrides),
+            "HTTP_CALLS" => Ok(Self::HttpCalls),
+            "PUBLISHES_TO" => Ok(Self::PublishesTo),
+            "SUBSCRIBES_TO" => Ok(Self::SubscribesTo),
             _ => Err(CodememError::InvalidRelationshipType(s.to_string())),
         }
     }

--- a/crates/codemem-engine/rules/go/symbols.yml
+++ b/crates/codemem-engine/rules/go/symbols.yml
@@ -28,7 +28,7 @@ symbols:
     special: "go_const_declaration"
 
   - kind: "var_declaration"
-    symbol_kind: "constant"
+    symbol_kind: "field"
     name_field: "name"
     method_when_scoped: false
     is_scope: false

--- a/crates/codemem-engine/rules/python/references.yml
+++ b/crates/codemem-engine/rules/python/references.yml
@@ -6,8 +6,8 @@ references:
 
   - kind: "import_from_statement"
     reference_kind: "import"
-    name_field: "module_name"
-    special: null
+    name_field: null
+    special: "python_import_from"
 
   - kind: "call"
     reference_kind: "call"
@@ -25,6 +25,10 @@ scope_containers:
     body_field: "body"
 
   - kind: "function_definition"
+    name_field: "name"
+    body_field: "body"
+
+  - kind: "async_function_definition"
     name_field: "name"
     body_field: "body"
 

--- a/crates/codemem-engine/rules/python/symbols.yml
+++ b/crates/codemem-engine/rules/python/symbols.yml
@@ -6,6 +6,13 @@ symbols:
     is_scope: false
     special: null
 
+  - kind: "async_function_definition"
+    symbol_kind: "function"
+    name_field: "name"
+    method_when_scoped: true
+    is_scope: false
+    special: null
+
   - kind: "class_definition"
     symbol_kind: "class"
     name_field: "name"
@@ -27,6 +34,11 @@ scope_containers:
     is_method_scope: true
 
   - kind: "function_definition"
+    name_field: "name"
+    body_field: "body"
+    is_method_scope: false
+
+  - kind: "async_function_definition"
     name_field: "name"
     body_field: "body"
     is_method_scope: false

--- a/crates/codemem-engine/rules/rust/symbols.yml
+++ b/crates/codemem-engine/rules/rust/symbols.yml
@@ -17,7 +17,7 @@ symbols:
     symbol_kind: "enum"
     name_field: "name"
     method_when_scoped: false
-    is_scope: false
+    is_scope: true
     special: null
 
   - kind: "trait_item"
@@ -55,6 +55,13 @@ symbols:
     is_scope: true
     special: null
 
+  - kind: "macro_definition"
+    symbol_kind: "function"
+    name_field: "name"
+    method_when_scoped: false
+    is_scope: false
+    special: null
+
 scope_containers:
   - kind: "impl_item"
     name_field: "type"
@@ -67,6 +74,11 @@ scope_containers:
     is_method_scope: true
 
   - kind: "mod_item"
+    name_field: "name"
+    body_field: "body"
+    is_method_scope: false
+
+  - kind: "enum_item"
     name_field: "name"
     body_field: "body"
     is_method_scope: false

--- a/crates/codemem-engine/rules/typescript/symbols.yml
+++ b/crates/codemem-engine/rules/typescript/symbols.yml
@@ -13,6 +13,13 @@ symbols:
     is_scope: true
     special: null
 
+  - kind: "abstract_class_declaration"
+    symbol_kind: "class"
+    name_field: "name"
+    method_when_scoped: false
+    is_scope: true
+    special: null
+
   - kind: "interface_declaration"
     symbol_kind: "interface"
     name_field: "name"
@@ -55,12 +62,31 @@ symbols:
     is_scope: false
     special: null
 
+  # Arrow functions: const fn = () => {}
   - kind: "lexical_declaration"
     symbol_kind: "function"
     name_field: "name"
     method_when_scoped: false
     is_scope: false
     special: "ts_lexical_arrow"
+
+  # Non-arrow constants: const FOO = 42, const config = { ... }
+  # The ts_lexical_arrow handler returns None for non-arrow values,
+  # falling through to this rule which captures them as constants.
+  - kind: "lexical_declaration"
+    symbol_kind: "constant"
+    name_field: "name"
+    method_when_scoped: false
+    is_scope: false
+    special: null
+
+  # var declarations (legacy but still common)
+  - kind: "variable_declaration"
+    symbol_kind: "constant"
+    name_field: "name"
+    method_when_scoped: false
+    is_scope: false
+    special: null
 
   - kind: "module"
     symbol_kind: "module"
@@ -78,6 +104,11 @@ symbols:
 
 scope_containers:
   - kind: "class_declaration"
+    name_field: "name"
+    body_field: "body"
+    is_method_scope: true
+
+  - kind: "abstract_class_declaration"
     name_field: "name"
     body_field: "body"
     is_method_scope: true

--- a/crates/codemem-engine/src/enrichment_text.rs
+++ b/crates/codemem-engine/src/enrichment_text.rs
@@ -89,6 +89,25 @@ impl CodememEngine {
             ctx.push_str(&format!("\nRelated: {}", related.join("; ")));
         }
 
+        // Include typed parameters for better search matching
+        if !sym.parameters.is_empty() {
+            let params: Vec<String> = sym
+                .parameters
+                .iter()
+                .map(|p| {
+                    if let Some(ref ty) = p.type_annotation {
+                        format!("{}: {}", p.name, ty)
+                    } else {
+                        p.name.clone()
+                    }
+                })
+                .collect();
+            ctx.push_str(&format!("\nParams: ({})", params.join(", ")));
+        }
+        if let Some(ref ret) = sym.return_type {
+            ctx.push_str(&format!(" -> {}", ret));
+        }
+
         let mut body = format!("{}: {}", sym.qualified_name, sym.signature);
         if let Some(ref doc) = sym.doc_comment {
             body.push('\n');

--- a/crates/codemem-engine/src/file_indexing.rs
+++ b/crates/codemem-engine/src/file_indexing.rs
@@ -6,6 +6,48 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::Ordering;
 
+/// Check if a file is a spec file (OpenAPI/AsyncAPI) by name or content.
+///
+/// First checks well-known filenames. For other YAML/JSON files, peeks at
+/// the first bytes to look for `"openapi"`, `"swagger"`, or `"asyncapi"` keys.
+fn is_spec_file_with_content(path: &str, content: &[u8]) -> bool {
+    let filename = path.rsplit('/').next().unwrap_or(path);
+    let filename_lower = filename.to_lowercase();
+
+    // Fast path: well-known names
+    if matches!(
+        filename_lower.as_str(),
+        "openapi.yaml"
+            | "openapi.yml"
+            | "openapi.json"
+            | "swagger.yaml"
+            | "swagger.yml"
+            | "swagger.json"
+            | "asyncapi.yaml"
+            | "asyncapi.yml"
+            | "asyncapi.json"
+    ) {
+        return true;
+    }
+
+    // For any YAML/JSON file, peek at content for spec-identifying keys
+    let is_yaml_json = filename_lower.ends_with(".yaml")
+        || filename_lower.ends_with(".yml")
+        || filename_lower.ends_with(".json");
+    if !is_yaml_json {
+        return false;
+    }
+
+    let peek = std::str::from_utf8(&content[..content.len().min(300)]).unwrap_or("");
+    let peek_lower = peek.to_lowercase();
+    peek_lower.contains("\"openapi\"")
+        || peek_lower.contains("\"swagger\"")
+        || peek_lower.contains("\"asyncapi\"")
+        || peek_lower.contains("openapi:")
+        || peek_lower.contains("swagger:")
+        || peek_lower.contains("asyncapi:")
+}
+
 impl CodememEngine {
     // ── Index Persistence ────────────────────────────────────────────────
 
@@ -157,6 +199,20 @@ impl CodememEngine {
             }
             hash
         };
+
+        // Check if this is a spec file (OpenAPI/AsyncAPI). If so, re-parse it
+        // and update endpoints/channels rather than treating it as code.
+        if is_spec_file_with_content(&path_str, &content) {
+            self.reparse_spec_file(path, namespace.unwrap_or(""))?;
+            // Record hash after successful spec parse
+            if let Ok(mut cd_guard) = self.change_detector.lock() {
+                if let Some(cd) = cd_guard.as_mut() {
+                    cd.record_hash(&path_str, hash);
+                    let _ = cd.save_to_storage(&*self.storage, namespace.unwrap_or(""));
+                }
+            }
+            return Ok(());
+        }
 
         let parser = index::CodeParser::new();
 
@@ -552,6 +608,58 @@ impl CodememEngine {
         }
 
         Ok((symbols_cleaned, edges_cleaned))
+    }
+
+    // ── A3c: Spec File Re-parsing ──────────────────────────────────────
+
+    /// Re-parse a spec file (OpenAPI/AsyncAPI) and update stored endpoints/channels.
+    fn reparse_spec_file(&self, path: &Path, namespace: &str) -> Result<(), CodememError> {
+        use crate::index::spec_parser::{parse_asyncapi, parse_openapi, SpecFileResult};
+
+        let result = if let Some(openapi) = parse_openapi(path) {
+            Some(SpecFileResult::OpenApi(openapi))
+        } else {
+            parse_asyncapi(path).map(SpecFileResult::AsyncApi)
+        };
+
+        match result {
+            Some(SpecFileResult::OpenApi(spec)) => {
+                for ep in &spec.endpoints {
+                    let _ = self.storage.store_api_endpoint(
+                        &ep.method,
+                        &ep.path,
+                        ep.operation_id.as_deref().unwrap_or(""),
+                        namespace,
+                    );
+                }
+                tracing::info!(
+                    "Re-parsed OpenAPI spec: {} endpoints from {}",
+                    spec.endpoints.len(),
+                    path.display()
+                );
+            }
+            Some(SpecFileResult::AsyncApi(spec)) => {
+                for ch in &spec.channels {
+                    let _ = self.storage.store_event_channel(
+                        &ch.channel,
+                        &ch.direction,
+                        ch.protocol.as_deref().unwrap_or(""),
+                        ch.operation_id.as_deref().unwrap_or(""),
+                        namespace,
+                        ch.description.as_deref().unwrap_or(""),
+                    );
+                }
+                tracing::info!(
+                    "Re-parsed AsyncAPI spec: {} channels from {}",
+                    spec.channels.len(),
+                    path.display()
+                );
+            }
+            None => {
+                tracing::debug!("Not a recognized spec file: {}", path.display());
+            }
+        }
+        Ok(())
     }
 
     // ── A4: Unified Analyze Pipeline ────────────────────────────────────

--- a/crates/codemem-engine/src/index/api_surface.rs
+++ b/crates/codemem-engine/src/index/api_surface.rs
@@ -57,11 +57,29 @@ pub struct DetectedClientCall {
     pub line: usize,
 }
 
+/// A detected event channel interaction (publish or subscribe).
+#[derive(Debug, Clone, PartialEq)]
+pub struct DetectedEventCall {
+    /// Symbol making the event call.
+    pub caller: String,
+    /// Channel/topic name (if extractable from the call target).
+    pub channel: Option<String>,
+    /// "publish" or "subscribe".
+    pub direction: String,
+    /// Protocol: kafka, rabbitmq, redis, sqs, sns, nats.
+    pub protocol: String,
+    /// File path.
+    pub file_path: String,
+    /// Line number.
+    pub line: usize,
+}
+
 /// Result of API surface detection.
 #[derive(Debug, Default)]
 pub struct ApiSurfaceResult {
     pub endpoints: Vec<DetectedEndpoint>,
     pub client_calls: Vec<DetectedClientCall>,
+    pub event_calls: Vec<DetectedEventCall>,
 }
 
 /// Detect API endpoints from extracted symbols.
@@ -482,6 +500,254 @@ fn paths_match_with_params(actual: &str, pattern: &str) -> bool {
         .iter()
         .zip(pattern_parts.iter())
         .all(|(a, p)| a == p || (p.starts_with('{') && p.ends_with('}')))
+}
+
+// ── Feature 4: Go/Express endpoint detection from call references ──────────
+
+/// Route-registration call patterns: (target substring, framework).
+const ROUTE_REGISTRATION_PATTERNS: &[(&str, &str)] = &[
+    // Go stdlib
+    ("http.HandleFunc", "go-http"),
+    ("http.Handle", "go-http"),
+    // Go Gin
+    ("router.GET", "gin"),
+    ("router.POST", "gin"),
+    ("router.PUT", "gin"),
+    ("router.DELETE", "gin"),
+    ("router.PATCH", "gin"),
+    // Go Echo
+    ("e.GET", "echo"),
+    ("e.POST", "echo"),
+    ("e.PUT", "echo"),
+    ("e.DELETE", "echo"),
+    ("e.PATCH", "echo"),
+    // Go Chi / gorilla mux
+    ("mux.Handle", "mux"),
+    ("mux.HandleFunc", "mux"),
+    // Express.js
+    ("app.get", "express"),
+    ("app.post", "express"),
+    ("app.put", "express"),
+    ("app.delete", "express"),
+    ("app.patch", "express"),
+    ("router.get", "express"),
+    ("router.post", "express"),
+    ("router.put", "express"),
+    ("router.delete", "express"),
+    ("router.patch", "express"),
+];
+
+/// Detect API endpoints from call references (Go, Express.js, etc.).
+///
+/// These frameworks register routes via function calls rather than decorators,
+/// so they can't be detected from `Symbol.attributes`. Instead we scan
+/// `Reference` entries for known route-registration call targets.
+pub fn detect_endpoints_from_references(
+    references: &[Reference],
+    namespace: &str,
+) -> Vec<DetectedEndpoint> {
+    let mut endpoints = Vec::new();
+
+    for r in references {
+        if r.kind != ReferenceKind::Call {
+            continue;
+        }
+
+        for &(pattern, _framework) in ROUTE_REGISTRATION_PATTERNS {
+            if r.target_name == pattern
+                || r.target_name.ends_with(&format!(
+                    ".{}",
+                    pattern.split('.').next_back().unwrap_or("")
+                ))
+            {
+                let method = extract_method_from_call_target(&r.target_name);
+                // Path is not available from reference data (would need string
+                // literal analysis). Store handler-based identifier so the
+                // endpoint is at least registered for cross-service matching.
+                let handler_path = format!("handler:{}", r.source_qualified_name);
+                endpoints.push(DetectedEndpoint {
+                    id: format!(
+                        "ep:{namespace}:{}:{handler_path}",
+                        method.as_deref().unwrap_or("ANY")
+                    ),
+                    method,
+                    path: handler_path,
+                    handler: r.source_qualified_name.clone(),
+                    file_path: r.file_path.clone(),
+                    line: r.line,
+                });
+                break;
+            }
+        }
+    }
+
+    endpoints
+}
+
+/// Extract HTTP method from a route-registration call target.
+fn extract_method_from_call_target(target: &str) -> Option<String> {
+    let last_segment = target.rsplit('.').next().unwrap_or(target);
+    match last_segment {
+        "GET" | "get" => Some("GET".to_string()),
+        "POST" | "post" => Some("POST".to_string()),
+        "PUT" | "put" => Some("PUT".to_string()),
+        "DELETE" | "delete" => Some("DELETE".to_string()),
+        "PATCH" | "patch" => Some("PATCH".to_string()),
+        // HandleFunc, Handle — method not determinable from call target
+        _ => None,
+    }
+}
+
+// ── Feature 3: Event framework pattern detection ──────────────────────────
+
+/// Event framework call patterns: (target pattern, protocol, direction).
+const EVENT_PATTERNS: &[(&str, &str, &str)] = &[
+    // Kafka
+    ("producer.send", "kafka", "publish"),
+    ("producer.produce", "kafka", "publish"),
+    ("consumer.subscribe", "kafka", "subscribe"),
+    ("consumer.poll", "kafka", "subscribe"),
+    // RabbitMQ
+    ("channel.basic_publish", "rabbitmq", "publish"),
+    ("channel.basic_consume", "rabbitmq", "subscribe"),
+    ("channel.publish", "rabbitmq", "publish"),
+    ("channel.consume", "rabbitmq", "subscribe"),
+    // Redis pub/sub
+    ("redis.publish", "redis", "publish"),
+    ("redis.subscribe", "redis", "subscribe"),
+    ("client.publish", "redis", "publish"),
+    ("client.subscribe", "redis", "subscribe"),
+    // AWS SQS
+    ("sqs.send_message", "sqs", "publish"),
+    ("sqs.receive_message", "sqs", "subscribe"),
+    ("sqs.sendMessage", "sqs", "publish"),
+    ("sqs.receiveMessage", "sqs", "subscribe"),
+    // AWS SNS
+    ("sns.publish", "sns", "publish"),
+    // NATS
+    ("nc.publish", "nats", "publish"),
+    ("nc.subscribe", "nats", "subscribe"),
+    ("nats.publish", "nats", "publish"),
+    ("nats.subscribe", "nats", "subscribe"),
+    // EventEmitter / generic
+    ("emitter.emit", "event", "publish"),
+    ("emitter.on", "event", "subscribe"),
+];
+
+/// Java/Kotlin annotation patterns that indicate event listeners.
+const EVENT_ANNOTATION_PATTERNS: &[(&str, &str, &str)] = &[
+    ("KafkaListener", "kafka", "subscribe"),
+    ("RabbitListener", "rabbitmq", "subscribe"),
+    ("SqsListener", "sqs", "subscribe"),
+    ("JmsListener", "jms", "subscribe"),
+    ("EventListener", "event", "subscribe"),
+];
+
+/// Detect event channel interactions from call references and symbol annotations.
+pub fn detect_event_calls(references: &[Reference], symbols: &[Symbol]) -> Vec<DetectedEventCall> {
+    let mut events = Vec::new();
+
+    // Scan call references for event framework patterns
+    for r in references {
+        if r.kind != ReferenceKind::Call {
+            continue;
+        }
+
+        for &(pattern, protocol, direction) in EVENT_PATTERNS {
+            if r.target_name == pattern || r.target_name.ends_with(pattern) {
+                events.push(DetectedEventCall {
+                    caller: r.source_qualified_name.clone(),
+                    channel: None, // Would need string literal analysis
+                    direction: direction.to_string(),
+                    protocol: protocol.to_string(),
+                    file_path: r.file_path.clone(),
+                    line: r.line,
+                });
+                break;
+            }
+        }
+    }
+
+    // Scan symbol annotations for event listener patterns (Java/Kotlin style)
+    for sym in symbols {
+        for attr in &sym.attributes {
+            for &(annotation, protocol, direction) in EVENT_ANNOTATION_PATTERNS {
+                if attr.contains(annotation) {
+                    events.push(DetectedEventCall {
+                        caller: sym.qualified_name.clone(),
+                        channel: extract_path_from_decorator(attr),
+                        direction: direction.to_string(),
+                        protocol: protocol.to_string(),
+                        file_path: sym.file_path.clone(),
+                        line: sym.line_start,
+                    });
+                    break;
+                }
+            }
+        }
+    }
+
+    events
+}
+
+// ── Feature 5: Cross-service edge matching ────────────────────────────────
+
+/// Match event producers to consumers on the same channel and protocol.
+/// Returns pairs of (producer_caller, consumer_caller, channel, protocol, confidence).
+pub fn match_event_channels(
+    producers: &[DetectedEventCall],
+    consumers: &[DetectedEventCall],
+) -> Vec<(String, String, String, String, f64)> {
+    let mut matches = Vec::new();
+
+    for producer in producers {
+        for consumer in consumers {
+            if producer.protocol != consumer.protocol {
+                continue;
+            }
+            // Require at least one side to have a known channel name.
+            // Protocol-only matching (both channels unknown) would create O(n²)
+            // spurious edges between all producers and consumers of the same
+            // protocol within a namespace.
+            match (&producer.channel, &consumer.channel) {
+                (Some(pc), Some(cc)) => {
+                    let confidence = if pc == cc {
+                        0.95
+                    } else if channels_match_pattern(pc, cc) {
+                        0.8
+                    } else {
+                        continue;
+                    };
+                    matches.push((
+                        producer.caller.clone(),
+                        consumer.caller.clone(),
+                        pc.clone(),
+                        producer.protocol.clone(),
+                        confidence,
+                    ));
+                }
+                // One side has a channel, other doesn't — skip (insufficient data)
+                // Both unknown — skip (would be O(n²) noise)
+                _ => continue,
+            }
+        }
+    }
+
+    matches
+}
+
+/// Check if two channel names match, accounting for wildcards.
+/// e.g., "orders.*" matches "orders.created"
+fn channels_match_pattern(a: &str, b: &str) -> bool {
+    if a.contains('*') || a.contains('#') {
+        let prefix = a.trim_end_matches(['*', '#', '.']);
+        b.starts_with(prefix)
+    } else if b.contains('*') || b.contains('#') {
+        let prefix = b.trim_end_matches(['*', '#', '.']);
+        a.starts_with(prefix)
+    } else {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/codemem-engine/src/index/engine/references.rs
+++ b/crates/codemem-engine/src/index/engine/references.rs
@@ -97,6 +97,56 @@ impl super::AstGrepEngine {
                     }
                 }
             }
+            "python_import_from" => {
+                // `from module import name1, name2` — emit import refs for
+                // both the module AND each imported name so the graph has
+                // edges to the individual symbols, not just the module.
+                let module_name = node
+                    .field("module_name")
+                    .map(|n| n.text().to_string())
+                    .unwrap_or_default();
+                if !module_name.is_empty() {
+                    push_ref(
+                        references,
+                        &source_qn,
+                        module_name.clone(),
+                        ReferenceKind::Import,
+                        file_path,
+                        node.start_pos().line(),
+                    );
+                }
+                // Extract individual imported names from the `name` children
+                for child in node.children() {
+                    let ck = child.kind();
+                    if ck.as_ref() == "dotted_name" || ck.as_ref() == "aliased_import" {
+                        let name_text = if ck.as_ref() == "aliased_import" {
+                            // `from X import Y as Z` — extract `Y` (the `name` field)
+                            child
+                                .field("name")
+                                .map(|n| n.text().to_string())
+                                .unwrap_or_default()
+                        } else {
+                            child.text().to_string()
+                        };
+                        if !name_text.is_empty() && name_text != module_name && name_text != "*" {
+                            // Qualify with module: `flask.Flask` for `from flask import Flask`
+                            let qualified = if module_name.is_empty() {
+                                name_text
+                            } else {
+                                format!("{module_name}.{name_text}")
+                            };
+                            push_ref(
+                                references,
+                                &source_qn,
+                                qualified,
+                                ReferenceKind::Import,
+                                file_path,
+                                child.start_pos().line(),
+                            );
+                        }
+                    }
+                }
+            }
             "python_class_bases" => {
                 if let Some(name_node) = node.field("name") {
                     let class_name = name_node.text().to_string();
@@ -724,6 +774,12 @@ fn decompose_rust_use_path(path: &str) -> Vec<String> {
             }
             return results;
         }
+    }
+
+    // Strip glob `*` — emit the parent module as the import target.
+    // `use std::collections::*` becomes `std::collections`.
+    if let Some(stripped) = path.strip_suffix("::*") {
+        return vec![stripped.to_string()];
     }
 
     // No group: return the path as-is

--- a/crates/codemem-engine/src/index/engine/visibility/mod.rs
+++ b/crates/codemem-engine/src/index/engine/visibility/mod.rs
@@ -135,7 +135,8 @@ impl crate::index::engine::AstGrepEngine {
                         }
                     }
                 }
-                Visibility::Private
+                // Swift's default access level is `internal`, not `private`
+                Visibility::Crate
             }
             "php" => {
                 for child in node.children() {

--- a/crates/codemem-engine/src/index/manifest.rs
+++ b/crates/codemem-engine/src/index/manifest.rs
@@ -325,13 +325,13 @@ pub fn parse_go_mod(path: &Path) -> Option<ManifestResult> {
 
 /// Parse a single Go require line like `github.com/pkg/errors v0.9.1`
 fn parse_go_require_line(line: &str, manifest_path: &str) -> Option<Dependency> {
-    // Remove inline comments
-    let line = line.split("//").next()?.trim();
-    let mut parts = line.split_whitespace();
+    // Check for indirect marker BEFORE stripping comments (the marker IS a comment)
+    let is_indirect = line.contains("// indirect");
+    // Remove inline comments for name/version extraction
+    let cleaned = line.split("//").next()?.trim();
+    let mut parts = cleaned.split_whitespace();
     let name = parts.next()?;
     let version = parts.next().unwrap_or("");
-    // Skip indirect dependencies marker, but still capture them
-    let is_indirect = line.contains("// indirect");
     Some(Dependency {
         name: name.to_string(),
         version: version.to_string(),

--- a/crates/codemem-engine/src/index/mod.rs
+++ b/crates/codemem-engine/src/index/mod.rs
@@ -12,11 +12,13 @@ pub mod parser;
 pub mod resolver;
 pub mod rule_loader;
 pub mod scip;
+pub mod spec_parser;
 pub mod symbol;
 
 pub use api_surface::{
-    detect_client_calls, detect_endpoints, match_endpoint, normalize_path_pattern,
-    ApiSurfaceResult, DetectedClientCall, DetectedEndpoint,
+    detect_client_calls, detect_endpoints, detect_endpoints_from_references, detect_event_calls,
+    match_endpoint, match_event_channels, normalize_path_pattern, ApiSurfaceResult,
+    DetectedClientCall, DetectedEndpoint, DetectedEventCall,
 };
 pub use chunker::{ChunkConfig, CodeChunk};
 pub use indexer::{IndexAndResolveResult, IndexProgress, IndexResult, Indexer};
@@ -28,4 +30,8 @@ pub use manifest::{Dependency, ManifestResult, Workspace};
 pub use parser::{CodeParser, ParseResult};
 pub use resolver::{ReferenceResolver, ResolveResult, ResolvedEdge, UnresolvedRef};
 pub use scip::orchestrate::{OrchestrationResult, ScipLanguage, ScipOrchestrator};
+pub use spec_parser::{
+    parse_asyncapi, parse_openapi, scan_api_specs, AsyncApiParseResult, SpecChannel, SpecEndpoint,
+    SpecFileResult, SpecParseResult,
+};
 pub use symbol::{Reference, ReferenceKind, Symbol, SymbolKind, Visibility};

--- a/crates/codemem-engine/src/index/scip/graph_builder.rs
+++ b/crates/codemem-engine/src/index/scip/graph_builder.rs
@@ -320,9 +320,25 @@ pub fn build_graph(
                 edges.push(Edge {
                     id: format!("typedef:{node_id}->{target_node_id}"),
                     src: node_id.clone(),
-                    dst: target_node_id,
+                    dst: target_node_id.clone(),
                     relationship: RelationshipType::TypeDefinition,
                     weight: 0.6,
+                    properties: scip_edge_properties(),
+                    created_at: now,
+                    valid_from: Some(now),
+                    valid_to: None,
+                });
+            }
+            // `is_reference` on a relationship indicates a superclass/supertype
+            // reference (e.g., class Dog extends Animal — Dog's SymbolInformation
+            // has a relationship to Animal with is_reference=true). Map to Inherits.
+            if rel.is_reference && !rel.is_implementation {
+                edges.push(Edge {
+                    id: format!("inherits:{node_id}->{target_node_id}"),
+                    src: node_id.clone(),
+                    dst: target_node_id,
+                    relationship: RelationshipType::Inherits,
+                    weight: 0.8,
                     properties: scip_edge_properties(),
                     created_at: now,
                     valid_from: Some(now),
@@ -507,77 +523,76 @@ pub fn build_graph(
             continue;
         }
 
-        // Some indexers (e.g., scip-go) set all references to READ_ACCESS without
-        // differentiating imports, writes, or calls. When the role is ONLY READ_ACCESS
-        // with no IMPORT or WRITE flags, treat as a generic reference (→ CALLS edge).
+        // Pick the most specific role for each reference. Priority:
+        //   IMPORT > WRITE > READ > generic CALLS
+        // A reference can have multiple role flags (e.g., IMPORT + READ_ACCESS),
+        // but we emit one edge per reference to avoid double-counting in
+        // PageRank — the more specific role subsumes the less specific one.
+        //
+        // scip-go workaround: scip-go sets READ_ACCESS on ALL references
+        // without semantic differentiation. When ONLY READ_ACCESS is set
+        // (no IMPORT, WRITE), fall through to CALLS.
         let semantic_mask = ROLE_IMPORT | ROLE_WRITE_ACCESS | ROLE_READ_ACCESS;
-        let roles = if r.role_bitmask & semantic_mask == ROLE_READ_ACCESS {
-            0 // Falls through to the generic CALLS branch
+        let is_scip_go_generic = r.role_bitmask & semantic_mask == ROLE_READ_ACCESS;
+
+        let (rel, weight) = if is_import_ref(r.role_bitmask) {
+            (RelationshipType::Imports, 0.5)
+        } else if is_write_ref(r.role_bitmask) {
+            (RelationshipType::Writes, 0.4)
+        } else if is_read_ref(r.role_bitmask) && !is_scip_go_generic {
+            (RelationshipType::Reads, 0.3)
         } else {
-            r.role_bitmask
+            (RelationshipType::Calls, 1.0)
         };
 
-        if is_import_ref(roles) {
-            edges.push(Edge {
-                id: format!(
-                    "imports:{source_node_id}->{target_node_id}:{}:{}",
-                    r.file_path, r.line
-                ),
-                src: source_node_id.clone(),
-                dst: target_node_id.clone(),
-                relationship: RelationshipType::Imports,
-                weight: 0.5,
-                properties: scip_edge_properties(),
-                created_at: now,
-                valid_from: Some(now),
-                valid_to: None,
-            });
-        } else if is_write_ref(roles) {
-            edges.push(Edge {
-                id: format!(
-                    "writes:{source_node_id}->{target_node_id}:{}:{}",
-                    r.file_path, r.line
-                ),
-                src: source_node_id.clone(),
-                dst: target_node_id.clone(),
-                relationship: RelationshipType::Writes,
-                weight: 0.4,
-                properties: scip_edge_properties(),
-                created_at: now,
-                valid_from: Some(now),
-                valid_to: None,
-            });
-        } else if is_read_ref(roles) {
-            edges.push(Edge {
-                id: format!(
-                    "reads:{source_node_id}->{target_node_id}:{}:{}",
-                    r.file_path, r.line
-                ),
-                src: source_node_id.clone(),
-                dst: target_node_id.clone(),
-                relationship: RelationshipType::Reads,
-                weight: 0.3,
-                properties: scip_edge_properties(),
-                created_at: now,
-                valid_from: Some(now),
-                valid_to: None,
-            });
-        } else {
-            // Generic reference — treat as CALLS.
-            edges.push(Edge {
-                id: format!(
-                    "calls:{source_node_id}->{target_node_id}:{}:{}",
-                    r.file_path, r.line
-                ),
-                src: source_node_id,
-                dst: target_node_id,
-                relationship: RelationshipType::Calls,
-                weight: 1.0,
-                properties: scip_edge_properties(),
-                created_at: now,
-                valid_from: Some(now),
-                valid_to: None,
-            });
+        let edge_prefix = rel.to_string().to_lowercase();
+        edges.push(Edge {
+            id: format!(
+                "{edge_prefix}:{source_node_id}->{target_node_id}:{}:{}",
+                r.file_path, r.line
+            ),
+            src: source_node_id.clone(),
+            dst: target_node_id.clone(),
+            relationship: rel,
+            weight,
+            properties: scip_edge_properties(),
+            created_at: now,
+            valid_from: Some(now),
+            valid_to: None,
+        });
+
+        // For non-import references to type-like symbols, also create a
+        // DependsOn edge. This captures "function X uses type Y" which is
+        // critical for blast-radius analysis. This is the ONE case where
+        // we emit two edges per reference — the structural relationship
+        // (Calls/Reads/Writes) AND the type dependency are distinct signals.
+        if !is_import_ref(r.role_bitmask) {
+            let is_type_target = matches!(
+                target_kind,
+                Some(
+                    NodeKind::Class
+                        | NodeKind::Trait
+                        | NodeKind::Interface
+                        | NodeKind::Type
+                        | NodeKind::Enum
+                )
+            );
+            if is_type_target {
+                edges.push(Edge {
+                    id: format!(
+                        "depends:{source_node_id}->{target_node_id}:{}:{}",
+                        r.file_path, r.line
+                    ),
+                    src: source_node_id,
+                    dst: target_node_id,
+                    relationship: RelationshipType::DependsOn,
+                    weight: 0.7,
+                    properties: scip_edge_properties(),
+                    created_at: now,
+                    valid_from: Some(now),
+                    valid_to: None,
+                });
+            }
         }
     }
 

--- a/crates/codemem-engine/src/index/spec_parser.rs
+++ b/crates/codemem-engine/src/index/spec_parser.rs
@@ -1,0 +1,625 @@
+//! OpenAPI and AsyncAPI spec file parsing.
+//!
+//! Parses OpenAPI (2.0/3.x) and AsyncAPI (2.x/3.0) specification files to extract
+//! API endpoints, channels, schemas, and metadata. Supports both JSON and YAML formats.
+//! Discovered endpoints are normalized via `api_surface::normalize_path_pattern()`.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+// ── OpenAPI Types ────────────────────────────────────────────────────────
+
+/// A single parsed endpoint from an OpenAPI/Swagger spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecEndpoint {
+    /// HTTP method (uppercase: GET, POST, etc.).
+    pub method: String,
+    /// URL path pattern (normalized).
+    pub path: String,
+    /// The `operationId` if present.
+    pub operation_id: Option<String>,
+    /// Operation description or summary.
+    pub description: Option<String>,
+    /// Stringified JSON of the request body schema.
+    pub request_schema: Option<String>,
+    /// Stringified JSON of the primary success response schema.
+    pub response_schema: Option<String>,
+    /// Path to the spec file this was extracted from.
+    pub spec_file: String,
+}
+
+/// Result of parsing an OpenAPI/Swagger spec file.
+#[derive(Debug, Clone)]
+pub struct SpecParseResult {
+    /// All endpoints discovered in the spec.
+    pub endpoints: Vec<SpecEndpoint>,
+    /// API title from `info.title`.
+    pub title: Option<String>,
+    /// API version from `info.version`.
+    pub version: Option<String>,
+}
+
+// ── AsyncAPI Types ───────────────────────────────────────────────────────
+
+/// A single parsed channel operation from an AsyncAPI spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecChannel {
+    /// Channel name/path.
+    pub channel: String,
+    /// Direction: `"publish"` or `"subscribe"`.
+    pub direction: String,
+    /// Protocol (e.g., `"kafka"`, `"amqp"`, `"mqtt"`).
+    pub protocol: Option<String>,
+    /// Stringified JSON of the message payload schema.
+    pub message_schema: Option<String>,
+    /// Operation description.
+    pub description: Option<String>,
+    /// The `operationId` if present.
+    pub operation_id: Option<String>,
+    /// Path to the spec file this was extracted from.
+    pub spec_file: String,
+}
+
+/// Result of parsing an AsyncAPI spec file.
+#[derive(Debug, Clone)]
+pub struct AsyncApiParseResult {
+    /// All channel operations discovered in the spec.
+    pub channels: Vec<SpecChannel>,
+    /// API title from `info.title`.
+    pub title: Option<String>,
+    /// API version from `info.version`.
+    pub version: Option<String>,
+}
+
+// ── Unified Result ───────────────────────────────────────────────────────
+
+/// A parsed spec file: either OpenAPI or AsyncAPI.
+#[derive(Debug, Clone)]
+pub enum SpecFileResult {
+    OpenApi(SpecParseResult),
+    AsyncApi(AsyncApiParseResult),
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// HTTP methods recognized in OpenAPI path items.
+const HTTP_METHODS: &[&str] = &["get", "post", "put", "delete", "patch", "options", "head"];
+
+/// Read a file and parse it into `serde_json::Value`, detecting JSON vs YAML by extension.
+fn read_spec_file(path: &Path) -> Option<serde_json::Value> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    match ext.as_str() {
+        "json" => serde_json::from_str(&content).ok(),
+        "yaml" | "yml" => {
+            let yaml_val: serde_yaml::Value = serde_yaml::from_str(&content).ok()?;
+            // Convert serde_yaml::Value → serde_json::Value via serialization round-trip.
+            let json_str = serde_json::to_string(&yaml_val).ok()?;
+            serde_json::from_str(&json_str).ok()
+        }
+        _ => {
+            // Unknown extension: try JSON first, then YAML.
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                return Some(v);
+            }
+            let yaml_val: serde_yaml::Value = serde_yaml::from_str(&content).ok()?;
+            let json_str = serde_json::to_string(&yaml_val).ok()?;
+            serde_json::from_str(&json_str).ok()
+        }
+    }
+}
+
+/// Stringify a `serde_json::Value` for schema storage.
+/// Returns `None` for `Value::Null`.
+fn stringify_schema(value: &serde_json::Value) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+    Some(serde_json::to_string(value).unwrap_or_default())
+}
+
+/// Extract `info.title` from a parsed spec.
+fn extract_info_title(root: &serde_json::Value) -> Option<String> {
+    root.get("info")?
+        .get("title")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+/// Extract `info.version` from a parsed spec.
+fn extract_info_version(root: &serde_json::Value) -> Option<String> {
+    root.get("info")?
+        .get("version")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+// ── OpenAPI Parsing ──────────────────────────────────────────────────────
+
+/// Parse an OpenAPI (2.0 Swagger / 3.x) spec file.
+///
+/// Returns `None` if the file cannot be read, is not valid JSON/YAML,
+/// or lacks an `openapi` or `swagger` top-level key.
+pub fn parse_openapi(path: &Path) -> Option<SpecParseResult> {
+    let root = read_spec_file(path)?;
+    let obj = root.as_object()?;
+
+    // Confirm this is an OpenAPI/Swagger file.
+    let is_openapi = obj.contains_key("openapi");
+    let is_swagger = obj.contains_key("swagger");
+    if !is_openapi && !is_swagger {
+        return None;
+    }
+
+    let spec_file = path.to_string_lossy().to_string();
+    let title = extract_info_title(&root);
+    let version = extract_info_version(&root);
+
+    let mut endpoints = Vec::new();
+
+    let paths = match obj.get("paths").and_then(|v| v.as_object()) {
+        Some(p) => p,
+        None => {
+            return Some(SpecParseResult {
+                endpoints,
+                title,
+                version,
+            })
+        }
+    };
+
+    for (url_path, path_item) in paths {
+        let path_obj = match path_item.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        let normalized = super::api_surface::normalize_path_pattern(url_path);
+
+        for method in HTTP_METHODS {
+            let operation = match path_obj.get(*method).and_then(|v| v.as_object()) {
+                Some(op) => op,
+                None => continue,
+            };
+
+            let operation_id = operation
+                .get("operationId")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            // Prefer summary, fall back to description.
+            let description = operation
+                .get("summary")
+                .and_then(|v| v.as_str())
+                .or_else(|| operation.get("description").and_then(|v| v.as_str()))
+                .map(|s| s.to_string());
+
+            let request_schema = if is_swagger {
+                extract_swagger_request_schema(operation)
+            } else {
+                extract_openapi3_request_schema(operation)
+            };
+
+            let response_schema = if is_swagger {
+                extract_swagger_response_schema(operation)
+            } else {
+                extract_openapi3_response_schema(operation)
+            };
+
+            endpoints.push(SpecEndpoint {
+                method: method.to_uppercase(),
+                path: normalized.clone(),
+                operation_id,
+                description,
+                request_schema,
+                response_schema,
+                spec_file: spec_file.clone(),
+            });
+        }
+    }
+
+    Some(SpecParseResult {
+        endpoints,
+        title,
+        version,
+    })
+}
+
+/// Extract request body schema from an OpenAPI 3.x operation.
+/// Looks for `requestBody.content.application/json.schema`.
+fn extract_openapi3_request_schema(
+    operation: &serde_json::Map<String, serde_json::Value>,
+) -> Option<String> {
+    let schema = operation
+        .get("requestBody")?
+        .get("content")?
+        .get("application/json")?
+        .get("schema")?;
+    stringify_schema(schema)
+}
+
+/// Extract response schema from an OpenAPI 3.x operation.
+/// Checks `responses.200` then `responses.201` for `content.application/json.schema`.
+fn extract_openapi3_response_schema(
+    operation: &serde_json::Map<String, serde_json::Value>,
+) -> Option<String> {
+    let responses = operation.get("responses")?.as_object()?;
+
+    for status in &["200", "201"] {
+        if let Some(schema) = responses
+            .get(*status)
+            .and_then(|r| r.get("content"))
+            .and_then(|c| c.get("application/json"))
+            .and_then(|j| j.get("schema"))
+        {
+            return stringify_schema(schema);
+        }
+    }
+    None
+}
+
+/// Extract request body schema from a Swagger 2.0 operation.
+/// Looks for a parameter with `in: body` and extracts its `schema`.
+fn extract_swagger_request_schema(
+    operation: &serde_json::Map<String, serde_json::Value>,
+) -> Option<String> {
+    let parameters = operation.get("parameters")?.as_array()?;
+    for param in parameters {
+        if param.get("in").and_then(|v| v.as_str()) == Some("body") {
+            if let Some(schema) = param.get("schema") {
+                return stringify_schema(schema);
+            }
+        }
+    }
+    None
+}
+
+/// Extract response schema from a Swagger 2.0 operation.
+/// Checks `responses.200.schema` then `responses.201.schema`.
+fn extract_swagger_response_schema(
+    operation: &serde_json::Map<String, serde_json::Value>,
+) -> Option<String> {
+    let responses = operation.get("responses")?.as_object()?;
+
+    for status in &["200", "201"] {
+        if let Some(schema) = responses.get(*status).and_then(|r| r.get("schema")) {
+            return stringify_schema(schema);
+        }
+    }
+    None
+}
+
+// ── AsyncAPI Parsing ─────────────────────────────────────────────────────
+
+/// Parse an AsyncAPI (2.x / 3.0) spec file.
+///
+/// Returns `None` if the file cannot be read, is not valid JSON/YAML,
+/// or lacks an `asyncapi` top-level key.
+pub fn parse_asyncapi(path: &Path) -> Option<AsyncApiParseResult> {
+    let root = read_spec_file(path)?;
+    let obj = root.as_object()?;
+
+    if !obj.contains_key("asyncapi") {
+        return None;
+    }
+
+    let spec_file = path.to_string_lossy().to_string();
+    let title = extract_info_title(&root);
+    let version = extract_info_version(&root);
+
+    // Detect protocol from servers object.
+    let protocol = detect_asyncapi_protocol(obj);
+
+    let asyncapi_version = obj.get("asyncapi").and_then(|v| v.as_str()).unwrap_or("");
+
+    let channels = if asyncapi_version.starts_with("3.") {
+        parse_asyncapi_v3(obj, &spec_file, &protocol)
+    } else {
+        // 2.x (default)
+        parse_asyncapi_v2(obj, &spec_file, &protocol)
+    };
+
+    Some(AsyncApiParseResult {
+        channels,
+        title,
+        version,
+    })
+}
+
+/// Detect the protocol from the `servers` object (first server's `protocol` field).
+fn detect_asyncapi_protocol(obj: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
+    let servers = obj.get("servers")?.as_object()?;
+    // Take the first server entry.
+    let (_name, server) = servers.iter().next()?;
+    server
+        .get("protocol")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Parse AsyncAPI 2.x channels.
+///
+/// Structure: `channels.<name>.publish` / `channels.<name>.subscribe`, each with
+/// `operationId`, `description`, `message.payload`.
+fn parse_asyncapi_v2(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    spec_file: &str,
+    protocol: &Option<String>,
+) -> Vec<SpecChannel> {
+    let mut result = Vec::new();
+
+    let channels = match obj.get("channels").and_then(|v| v.as_object()) {
+        Some(c) => c,
+        None => return result,
+    };
+
+    for (channel_name, channel_value) in channels {
+        let channel_obj = match channel_value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        for direction in &["publish", "subscribe"] {
+            let operation = match channel_obj.get(*direction).and_then(|v| v.as_object()) {
+                Some(op) => op,
+                None => continue,
+            };
+
+            let operation_id = operation
+                .get("operationId")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            let description = operation
+                .get("description")
+                .and_then(|v| v.as_str())
+                .or_else(|| operation.get("summary").and_then(|v| v.as_str()))
+                .map(|s| s.to_string());
+
+            let message_schema = operation
+                .get("message")
+                .and_then(|m| m.get("payload"))
+                .and_then(stringify_schema);
+
+            result.push(SpecChannel {
+                channel: channel_name.clone(),
+                direction: direction.to_string(),
+                protocol: protocol.clone(),
+                message_schema,
+                description,
+                operation_id,
+                spec_file: spec_file.to_string(),
+            });
+        }
+    }
+
+    result
+}
+
+/// Parse AsyncAPI 3.0 channels and operations.
+///
+/// In v3, channels are under `channels` and operations are under `operations`.
+/// Each operation has a `channel.$ref` pointing to a channel, plus `action` (send/receive).
+fn parse_asyncapi_v3(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    spec_file: &str,
+    protocol: &Option<String>,
+) -> Vec<SpecChannel> {
+    let mut result = Vec::new();
+
+    let operations = match obj.get("operations").and_then(|v| v.as_object()) {
+        Some(o) => o,
+        None => return result,
+    };
+
+    for (_op_name, op_value) in operations {
+        let operation = match op_value.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+
+        // Resolve channel name from $ref: "#/channels/channelName"
+        let channel_name = operation
+            .get("channel")
+            .and_then(|c| {
+                // Could be a $ref object or a direct reference.
+                if let Some(ref_str) = c.get("$ref").and_then(|v| v.as_str()) {
+                    // Extract last segment: "#/channels/myChannel" → "myChannel"
+                    ref_str.rsplit('/').next().map(|s| s.to_string())
+                } else {
+                    c.as_str().map(|s| s.to_string())
+                }
+            })
+            .unwrap_or_default();
+
+        // action: "send" or "receive" → map to "publish"/"subscribe"
+        let direction = match operation.get("action").and_then(|v| v.as_str()) {
+            Some("send") => "publish".to_string(),
+            Some("receive") => "subscribe".to_string(),
+            Some(other) => other.to_string(),
+            None => continue,
+        };
+
+        let operation_id = operation
+            .get("operationId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let description = operation
+            .get("description")
+            .and_then(|v| v.as_str())
+            .or_else(|| operation.get("summary").and_then(|v| v.as_str()))
+            .map(|s| s.to_string());
+
+        // In v3, messages can be on the operation or on the channel.
+        let message_schema = extract_v3_message_schema(operation, obj, &channel_name);
+
+        result.push(SpecChannel {
+            channel: channel_name,
+            direction,
+            protocol: protocol.clone(),
+            message_schema,
+            description,
+            operation_id,
+            spec_file: spec_file.to_string(),
+        });
+    }
+
+    result
+}
+
+/// Extract message payload schema for an AsyncAPI 3.0 operation.
+///
+/// Checks the operation's `messages` first, then falls back to the channel's
+/// `messages` in the root `channels` object.
+fn extract_v3_message_schema(
+    operation: &serde_json::Map<String, serde_json::Value>,
+    root: &serde_json::Map<String, serde_json::Value>,
+    channel_name: &str,
+) -> Option<String> {
+    // Try operation-level messages first.
+    if let Some(messages) = operation.get("messages") {
+        if let Some(schema) = first_message_payload(messages) {
+            return Some(schema);
+        }
+    }
+
+    // Fall back to channel-level messages.
+    let channel = root.get("channels")?.get(channel_name)?;
+    let messages = channel.get("messages")?;
+    first_message_payload(messages)
+}
+
+/// Extract the `payload` schema from the first message in a messages value.
+/// Messages can be an object (keyed by name) or an array.
+fn first_message_payload(messages: &serde_json::Value) -> Option<String> {
+    if let Some(obj) = messages.as_object() {
+        for (_name, msg) in obj {
+            if let Some(payload) = msg.get("payload") {
+                return stringify_schema(payload);
+            }
+        }
+    } else if let Some(arr) = messages.as_array() {
+        for msg in arr {
+            if let Some(payload) = msg.get("payload") {
+                return stringify_schema(payload);
+            }
+        }
+    }
+    None
+}
+
+// ── Directory Scanning ───────────────────────────────────────────────────
+
+/// Well-known spec file names to match by filename alone.
+const SPEC_FILE_NAMES: &[&str] = &[
+    "openapi.yaml",
+    "openapi.yml",
+    "openapi.json",
+    "swagger.yaml",
+    "swagger.yml",
+    "swagger.json",
+    "asyncapi.yaml",
+    "asyncapi.yml",
+    "asyncapi.json",
+];
+
+/// Scan a directory for API spec files (OpenAPI / AsyncAPI) and parse them.
+///
+/// Uses `ignore::WalkBuilder` to walk the directory tree, respecting `.gitignore`.
+/// Detects spec files by well-known filenames and by peeking at file contents
+/// for top-level `openapi`, `swagger`, or `asyncapi` keys.
+pub fn scan_api_specs(root: &Path) -> Vec<SpecFileResult> {
+    let mut results = Vec::new();
+
+    let walker = ignore::WalkBuilder::new(root)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+
+        let path = entry.path();
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        // Only consider JSON/YAML files.
+        if !matches!(ext.as_str(), "json" | "yaml" | "yml") {
+            continue;
+        }
+
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        let is_well_known = SPEC_FILE_NAMES.contains(&file_name.as_str());
+
+        if !is_well_known {
+            // Peek at the file to check for spec-identifying keys.
+            if !peek_is_spec_file(path) {
+                continue;
+            }
+        }
+
+        // Try OpenAPI first, then AsyncAPI.
+        if let Some(openapi) = parse_openapi(path) {
+            results.push(SpecFileResult::OpenApi(openapi));
+        } else if let Some(asyncapi) = parse_asyncapi(path) {
+            results.push(SpecFileResult::AsyncApi(asyncapi));
+        }
+    }
+
+    results
+}
+
+/// Quick check: read the first 200 bytes and look for spec-identifying keys.
+fn peek_is_spec_file(path: &Path) -> bool {
+    let mut buf = [0u8; 200];
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+
+    use std::io::Read;
+    let mut reader = std::io::BufReader::new(file);
+    let n = match reader.read(&mut buf) {
+        Ok(n) => n,
+        Err(_) => return false,
+    };
+
+    let snippet = String::from_utf8_lossy(&buf[..n]).to_lowercase();
+
+    // Check for top-level keys that identify spec files.
+    // In YAML: `openapi:` or `swagger:` or `asyncapi:` at start of line.
+    // In JSON: `"openapi"` or `"swagger"` or `"asyncapi"` near the start.
+    snippet.contains("\"openapi\"")
+        || snippet.contains("\"swagger\"")
+        || snippet.contains("\"asyncapi\"")
+        || snippet.contains("openapi:")
+        || snippet.contains("swagger:")
+        || snippet.contains("asyncapi:")
+}
+
+#[cfg(test)]
+#[path = "tests/spec_parser_tests.rs"]
+mod tests;

--- a/crates/codemem-engine/src/index/tests/spec_parser_tests.rs
+++ b/crates/codemem-engine/src/index/tests/spec_parser_tests.rs
@@ -1,0 +1,465 @@
+use super::*;
+use std::io::Write;
+use tempfile::TempDir;
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn write_temp_file(dir: &TempDir, name: &str, content: &str) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+    path
+}
+
+fn write_json_file(dir: &TempDir, name: &str, value: &serde_json::Value) -> std::path::PathBuf {
+    let content = serde_json::to_string_pretty(value).unwrap();
+    write_temp_file(dir, name, &content)
+}
+
+// ── OpenAPI 3.x Tests ───────────────────────────────────────────────────
+
+#[test]
+fn test_parse_openapi3_json() {
+    let dir = TempDir::new().unwrap();
+    let spec = serde_json::json!({
+        "openapi": "3.0.3",
+        "info": { "title": "Pet Store", "version": "1.0.0" },
+        "paths": {
+            "/pets": {
+                "get": {
+                    "operationId": "listPets",
+                    "summary": "List all pets",
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": { "$ref": "#/components/schemas/Pet" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "post": {
+                    "operationId": "createPet",
+                    "description": "Create a pet",
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": { "$ref": "#/components/schemas/Pet" }
+                            }
+                        }
+                    },
+                    "responses": {
+                        "201": {
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/Pet" }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/pets/{petId}": {
+                "get": {
+                    "operationId": "showPetById",
+                    "summary": "Info for a specific pet",
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/Pet" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let path = write_json_file(&dir, "openapi.json", &spec);
+    let result = parse_openapi(&path).unwrap();
+
+    assert_eq!(result.title.as_deref(), Some("Pet Store"));
+    assert_eq!(result.version.as_deref(), Some("1.0.0"));
+    assert_eq!(result.endpoints.len(), 3);
+
+    let get_pets = result
+        .endpoints
+        .iter()
+        .find(|e| e.method == "GET" && e.path == "/pets")
+        .unwrap();
+    assert_eq!(get_pets.operation_id.as_deref(), Some("listPets"));
+    assert_eq!(get_pets.description.as_deref(), Some("List all pets"));
+    assert!(get_pets.response_schema.is_some());
+    assert!(get_pets.request_schema.is_none());
+
+    let create_pet = result
+        .endpoints
+        .iter()
+        .find(|e| e.method == "POST")
+        .unwrap();
+    assert_eq!(create_pet.operation_id.as_deref(), Some("createPet"));
+    assert!(create_pet.request_schema.is_some());
+    assert!(create_pet.response_schema.is_some());
+
+    let get_by_id = result
+        .endpoints
+        .iter()
+        .find(|e| e.path == "/pets/{petId}")
+        .unwrap();
+    assert_eq!(get_by_id.operation_id.as_deref(), Some("showPetById"));
+}
+
+#[test]
+fn test_parse_openapi3_yaml() {
+    let dir = TempDir::new().unwrap();
+    let content = "\
+openapi: \"3.0.0\"
+info:
+  title: Users API
+  version: \"2.0\"
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      summary: Get all users
+      responses:
+        \"200\":
+          content:
+            application/json:
+              schema:
+                type: array
+";
+
+    let path = write_temp_file(&dir, "openapi.yaml", content);
+    let result = parse_openapi(&path).unwrap();
+
+    assert_eq!(result.title.as_deref(), Some("Users API"));
+    assert_eq!(result.version.as_deref(), Some("2.0"));
+    assert_eq!(result.endpoints.len(), 1);
+    assert_eq!(result.endpoints[0].method, "GET");
+    assert_eq!(result.endpoints[0].path, "/users");
+}
+
+// ── Swagger 2.0 Tests ───────────────────────────────────────────────────
+
+#[test]
+fn test_parse_swagger2_json() {
+    let dir = TempDir::new().unwrap();
+    let spec = serde_json::json!({
+        "swagger": "2.0",
+        "info": { "title": "Legacy API", "version": "1.0" },
+        "paths": {
+            "/items": {
+                "post": {
+                    "operationId": "createItem",
+                    "summary": "Create item",
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "name": "body",
+                            "schema": { "$ref": "#/definitions/Item" }
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "schema": { "$ref": "#/definitions/Item" }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let path = write_json_file(&dir, "swagger.json", &spec);
+    let result = parse_openapi(&path).unwrap();
+
+    assert_eq!(result.title.as_deref(), Some("Legacy API"));
+    assert_eq!(result.endpoints.len(), 1);
+
+    let ep = &result.endpoints[0];
+    assert_eq!(ep.method, "POST");
+    assert_eq!(ep.path, "/items");
+    assert!(ep.request_schema.is_some());
+    assert!(ep.response_schema.is_some());
+}
+
+// ── AsyncAPI 2.x Tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_parse_asyncapi2_yaml() {
+    let dir = TempDir::new().unwrap();
+    let content = "\
+asyncapi: \"2.6.0\"
+info:
+  title: Events Service
+  version: \"1.0.0\"
+servers:
+  production:
+    url: broker.example.com
+    protocol: kafka
+channels:
+  user.created:
+    publish:
+      operationId: publishUserCreated
+      description: User was created
+      message:
+        payload:
+          type: object
+          properties:
+            userId:
+              type: string
+    subscribe:
+      operationId: onUserCreated
+      description: Listen for user creation
+      message:
+        payload:
+          type: object
+";
+
+    let path = write_temp_file(&dir, "asyncapi.yaml", content);
+    let result = parse_asyncapi(&path).unwrap();
+
+    assert_eq!(result.title.as_deref(), Some("Events Service"));
+    assert_eq!(result.version.as_deref(), Some("1.0.0"));
+    assert_eq!(result.channels.len(), 2);
+
+    let pub_ch = result
+        .channels
+        .iter()
+        .find(|c| c.direction == "publish")
+        .unwrap();
+    assert_eq!(pub_ch.channel, "user.created");
+    assert_eq!(pub_ch.operation_id.as_deref(), Some("publishUserCreated"));
+    assert_eq!(pub_ch.protocol.as_deref(), Some("kafka"));
+    assert!(pub_ch.message_schema.is_some());
+
+    let sub_ch = result
+        .channels
+        .iter()
+        .find(|c| c.direction == "subscribe")
+        .unwrap();
+    assert_eq!(sub_ch.operation_id.as_deref(), Some("onUserCreated"));
+}
+
+// ── AsyncAPI 3.0 Tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_parse_asyncapi3_json() {
+    let dir = TempDir::new().unwrap();
+    let spec = serde_json::json!({
+        "asyncapi": "3.0.0",
+        "info": { "title": "Order Events", "version": "2.0.0" },
+        "servers": {
+            "main": { "host": "rabbitmq.example.com", "protocol": "amqp" }
+        },
+        "channels": {
+            "orderChannel": {
+                "messages": {
+                    "OrderCreated": {
+                        "payload": {
+                            "type": "object",
+                            "properties": { "orderId": { "type": "string" } }
+                        }
+                    }
+                }
+            }
+        },
+        "operations": {
+            "sendOrder": {
+                "action": "send",
+                "channel": { "$ref": "#/channels/orderChannel" },
+                "operationId": "sendOrder",
+                "description": "Send order event",
+                "messages": {
+                    "OrderCreated": {
+                        "payload": { "type": "object" }
+                    }
+                }
+            },
+            "receiveOrder": {
+                "action": "receive",
+                "channel": { "$ref": "#/channels/orderChannel" },
+                "operationId": "receiveOrder"
+            }
+        }
+    });
+
+    let path = write_json_file(&dir, "asyncapi.json", &spec);
+    let result = parse_asyncapi(&path).unwrap();
+
+    assert_eq!(result.title.as_deref(), Some("Order Events"));
+    assert_eq!(result.version.as_deref(), Some("2.0.0"));
+    assert_eq!(result.channels.len(), 2);
+
+    let send = result
+        .channels
+        .iter()
+        .find(|c| c.direction == "publish")
+        .unwrap();
+    assert_eq!(send.channel, "orderChannel");
+    assert_eq!(send.operation_id.as_deref(), Some("sendOrder"));
+    assert_eq!(send.protocol.as_deref(), Some("amqp"));
+    assert!(send.message_schema.is_some());
+
+    let recv = result
+        .channels
+        .iter()
+        .find(|c| c.direction == "subscribe")
+        .unwrap();
+    assert_eq!(recv.operation_id.as_deref(), Some("receiveOrder"));
+    // Falls back to channel-level message since operation has no messages
+    assert!(recv.message_schema.is_some());
+}
+
+// ── Edge Cases ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_nonexistent_file_returns_none() {
+    let path = std::path::Path::new("/tmp/does-not-exist-codemem-test.json");
+    assert!(parse_openapi(path).is_none());
+    assert!(parse_asyncapi(path).is_none());
+}
+
+#[test]
+fn test_invalid_json_returns_none() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp_file(&dir, "broken.json", "{ not valid json }}}");
+    assert!(parse_openapi(&path).is_none());
+}
+
+#[test]
+fn test_valid_json_but_not_spec_returns_none() {
+    let dir = TempDir::new().unwrap();
+    let spec = serde_json::json!({ "name": "hello", "version": "1.0" });
+    let path = write_json_file(&dir, "config.json", &spec);
+    assert!(parse_openapi(&path).is_none());
+    assert!(parse_asyncapi(&path).is_none());
+}
+
+#[test]
+fn test_openapi_missing_paths_returns_empty_endpoints() {
+    let dir = TempDir::new().unwrap();
+    let spec = serde_json::json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Empty", "version": "0.1" }
+    });
+    let path = write_json_file(&dir, "openapi.json", &spec);
+    let result = parse_openapi(&path).unwrap();
+    assert!(result.endpoints.is_empty());
+    assert_eq!(result.title.as_deref(), Some("Empty"));
+}
+
+#[test]
+fn test_asyncapi_missing_channels_returns_empty() {
+    let dir = TempDir::new().unwrap();
+    let spec = serde_json::json!({
+        "asyncapi": "2.0.0",
+        "info": { "title": "No channels", "version": "0.1" }
+    });
+    let path = write_json_file(&dir, "asyncapi.json", &spec);
+    let result = parse_asyncapi(&path).unwrap();
+    assert!(result.channels.is_empty());
+}
+
+#[test]
+fn test_openapi_path_normalization() {
+    let dir = TempDir::new().unwrap();
+    let spec = serde_json::json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Test", "version": "1" },
+        "paths": {
+            "users/{userId}/orders": {
+                "get": { "operationId": "getUserOrders" }
+            }
+        }
+    });
+    let path = write_json_file(&dir, "api.json", &spec);
+    let result = parse_openapi(&path).unwrap();
+    assert_eq!(result.endpoints.len(), 1);
+    // normalize_path_pattern adds leading slash if missing
+    assert!(result.endpoints[0].path.starts_with('/'));
+}
+
+// ── Directory Scanning ───────────────────────────────────────────────────
+
+#[test]
+fn test_scan_api_specs_finds_well_known_files() {
+    let dir = TempDir::new().unwrap();
+
+    let openapi_spec = serde_json::json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Scan Test", "version": "1" },
+        "paths": {
+            "/health": { "get": { "operationId": "healthCheck" } }
+        }
+    });
+
+    let asyncapi_spec = serde_json::json!({
+        "asyncapi": "2.0.0",
+        "info": { "title": "Events", "version": "1" },
+        "channels": {
+            "events": {
+                "publish": { "operationId": "pubEvent" }
+            }
+        }
+    });
+
+    write_json_file(&dir, "openapi.json", &openapi_spec);
+    write_json_file(&dir, "asyncapi.json", &asyncapi_spec);
+    // Non-spec file should be ignored
+    let non_spec = serde_json::json!({ "key": "value" });
+    write_json_file(&dir, "config.json", &non_spec);
+
+    let results = scan_api_specs(dir.path());
+    assert_eq!(results.len(), 2);
+
+    let has_openapi = results
+        .iter()
+        .any(|r| matches!(r, SpecFileResult::OpenApi(_)));
+    let has_asyncapi = results
+        .iter()
+        .any(|r| matches!(r, SpecFileResult::AsyncApi(_)));
+    assert!(has_openapi);
+    assert!(has_asyncapi);
+}
+
+#[test]
+fn test_scan_detects_non_well_known_spec_by_peeking() {
+    let dir = TempDir::new().unwrap();
+
+    let spec = serde_json::json!({
+        "openapi": "3.0.0",
+        "info": { "title": "Custom Named", "version": "1" },
+        "paths": {}
+    });
+
+    write_json_file(&dir, "my-api-spec.json", &spec);
+
+    let results = scan_api_specs(dir.path());
+    assert_eq!(results.len(), 1);
+
+    if let SpecFileResult::OpenApi(result) = &results[0] {
+        assert_eq!(result.title.as_deref(), Some("Custom Named"));
+    } else {
+        panic!("Expected OpenApi result");
+    }
+}
+
+#[test]
+fn test_scan_ignores_non_spec_yaml() {
+    let dir = TempDir::new().unwrap();
+    let content = "name: my-config\nversion: 1\nkey: value\n";
+    write_temp_file(&dir, "config.yaml", content);
+
+    let results = scan_api_specs(dir.path());
+    assert!(results.is_empty());
+}

--- a/crates/codemem-engine/src/persistence/cross_repo.rs
+++ b/crates/codemem-engine/src/persistence/cross_repo.rs
@@ -211,10 +211,16 @@ impl super::super::CodememEngine {
         }
 
         // ── Phase 3: API Surface ────────────────────────────────────────────
-        // 6. Detect API endpoints and client calls.
-        let endpoints = api_surface::detect_endpoints(symbols, namespace);
-        result.endpoints_detected = endpoints.len();
-        for ep in &endpoints {
+
+        // 6a. Detect endpoints from decorators/annotations (existing)
+        let mut all_endpoints = api_surface::detect_endpoints(symbols, namespace);
+
+        // 6b. Detect endpoints from call references (Go, Express.js)
+        let ref_endpoints = api_surface::detect_endpoints_from_references(references, namespace);
+        all_endpoints.extend(ref_endpoints);
+
+        result.endpoints_detected = all_endpoints.len();
+        for ep in &all_endpoints {
             if let Err(e) = self.storage.store_api_endpoint(
                 ep.method.as_deref().unwrap_or("ANY"),
                 &ep.path,
@@ -229,6 +235,7 @@ impl super::super::CodememEngine {
             }
         }
 
+        // 7. Detect HTTP client calls
         let client_calls = api_surface::detect_client_calls(references);
         result.client_calls_detected = client_calls.len();
         for call in &client_calls {
@@ -245,7 +252,154 @@ impl super::super::CodememEngine {
             }
         }
 
+        // 8. Detect event channel interactions (Kafka, RabbitMQ, Redis, SQS, etc.)
+        let event_calls = api_surface::detect_event_calls(references, symbols);
+        result.event_channels_detected = event_calls.len();
+        for ec in &event_calls {
+            if let Err(e) = self.storage.store_event_channel(
+                ec.channel.as_deref().unwrap_or("unknown"),
+                &ec.direction,
+                &ec.protocol,
+                &ec.caller,
+                namespace,
+                "",
+            ) {
+                tracing::warn!("Failed to store event channel for {}: {e}", ec.caller);
+            }
+        }
+
+        // ── Phase 4: Cross-service edge matching ──────────────────────────
+
+        // 9a. Match HTTP client calls to detected endpoints across namespaces
+        let all_stored_with_ns = self.get_all_stored_endpoints_with_ns();
+        let all_ep_list: Vec<api_surface::DetectedEndpoint> = all_stored_with_ns
+            .iter()
+            .map(|(ep, _)| ep.clone())
+            .collect();
+        for call in &client_calls {
+            if let Some(url) = &call.url_pattern {
+                if let Some((matched_ep, confidence)) =
+                    api_surface::match_endpoint(url, call.method.as_deref(), &all_ep_list)
+                {
+                    // Find the namespace for this matched endpoint
+                    let ep_ns = all_stored_with_ns
+                        .iter()
+                        .find(|(ep, _)| ep.id == matched_ep.id)
+                        .map(|(_, ns)| ns.as_str());
+                    // Only create cross-namespace edges
+                    if ep_ns != Some(namespace) {
+                        let edge = Edge {
+                            id: format!("http:{}->{}", call.caller, matched_ep.handler),
+                            src: format!("sym:{}", call.caller),
+                            dst: format!("sym:{}", matched_ep.handler),
+                            relationship: RelationshipType::HttpCalls,
+                            weight: confidence * 0.7,
+                            properties: {
+                                let mut p = HashMap::new();
+                                p.insert(
+                                    "cross_namespace".to_string(),
+                                    serde_json::Value::Bool(true),
+                                );
+                                p.insert(
+                                    "path".to_string(),
+                                    serde_json::Value::String(matched_ep.path.clone()),
+                                );
+                                p
+                            },
+                            created_at: chrono::Utc::now(),
+                            valid_from: Some(chrono::Utc::now()),
+                            valid_to: None,
+                        };
+                        if self.storage.insert_graph_edge(&edge).is_ok() {
+                            if let Ok(mut graph) = self.lock_graph() {
+                                let _ = graph.add_edge(edge);
+                            }
+                            result.http_edges_matched += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        // 9b. Match event producers to consumers across namespaces
+        let all_event_channels = self.storage.list_all_event_channels().unwrap_or_default();
+        let producers: Vec<api_surface::DetectedEventCall> = all_event_channels
+            .iter()
+            .filter(|ec| ec.1 == "publish")
+            .map(|ec| api_surface::DetectedEventCall {
+                caller: ec.3.clone(),
+                channel: Some(ec.0.clone()),
+                direction: "publish".to_string(),
+                protocol: ec.2.clone(),
+                file_path: String::new(),
+                line: 0,
+            })
+            .collect();
+        let consumers: Vec<api_surface::DetectedEventCall> = all_event_channels
+            .iter()
+            .filter(|ec| ec.1 == "subscribe")
+            .map(|ec| api_surface::DetectedEventCall {
+                caller: ec.3.clone(),
+                channel: Some(ec.0.clone()),
+                direction: "subscribe".to_string(),
+                protocol: ec.2.clone(),
+                file_path: String::new(),
+                line: 0,
+            })
+            .collect();
+
+        let event_matches = api_surface::match_event_channels(&producers, &consumers);
+        let now = chrono::Utc::now();
+        for (producer, consumer, channel, protocol, confidence) in &event_matches {
+            // Only create cross-namespace edges (different callers imply different namespaces in practice)
+            if producer == consumer {
+                continue;
+            }
+            let edge = Edge {
+                id: format!("event:{producer}->{consumer}:{protocol}:{channel}"),
+                src: format!("sym:{producer}"),
+                dst: format!("sym:{consumer}"),
+                relationship: RelationshipType::PublishesTo,
+                weight: confidence * 0.6,
+                properties: {
+                    let mut p = HashMap::new();
+                    p.insert(
+                        "channel".to_string(),
+                        serde_json::Value::String(channel.clone()),
+                    );
+                    p.insert(
+                        "protocol".to_string(),
+                        serde_json::Value::String(protocol.clone()),
+                    );
+                    p
+                },
+                created_at: now,
+                valid_from: Some(now),
+                valid_to: None,
+            };
+            if self.storage.insert_graph_edge(&edge).is_ok() {
+                if let Ok(mut graph) = self.lock_graph() {
+                    let _ = graph.add_edge(edge);
+                }
+                result.event_edges_matched += 1;
+            }
+        }
+
         Ok(result)
+    }
+
+    /// Get all stored endpoints across all namespaces, paired with their namespace.
+    fn get_all_stored_endpoints_with_ns(&self) -> Vec<(api_surface::DetectedEndpoint, String)> {
+        let namespaces = self.storage.list_namespaces().unwrap_or_default();
+        let mut all = Vec::new();
+        for ns in &namespaces {
+            if let Ok(eps) = self.get_detected_endpoints(ns) {
+                for ep in eps {
+                    all.push((ep, ns.clone()));
+                }
+            }
+        }
+        all
     }
 
     /// Persist a cross-repo edge into the graph_edges table and in-memory graph.

--- a/crates/codemem-engine/src/persistence/mod.rs
+++ b/crates/codemem-engine/src/persistence/mod.rs
@@ -32,6 +32,10 @@ pub struct CrossRepoPersistResult {
     pub backward_edges_created: usize,
     pub endpoints_detected: usize,
     pub client_calls_detected: usize,
+    pub spec_endpoints_detected: usize,
+    pub event_channels_detected: usize,
+    pub http_edges_matched: usize,
+    pub event_edges_matched: usize,
 }
 
 /// Return the edge weight for a given relationship type, using config overrides
@@ -51,6 +55,8 @@ pub fn edge_weight_for(rel: &RelationshipType, config: &GraphConfig) -> f64 {
         RelationshipType::EvolvedInto | RelationshipType::Summarizes => 0.7,
         RelationshipType::PartOf => 0.4,
         RelationshipType::RelatesTo | RelationshipType::SharesTheme => 0.3,
+        RelationshipType::HttpCalls => 0.7,
+        RelationshipType::PublishesTo | RelationshipType::SubscribesTo => 0.6,
         _ => 0.5,
     }
 }
@@ -596,6 +602,11 @@ impl super::CodememEngine {
                     serde_json::json!(Self::AST_GREP_BASE_CONFIDENCE),
                 );
                 properties.insert("source_layers".to_string(), serde_json::json!(["ast-grep"]));
+                // Scale edge weight by resolution confidence so low-confidence
+                // guesses (simple-name fallback) carry less weight in PageRank
+                // and betweenness centrality than exact matches.
+                let base_weight = edge_weight_for(&edge.relationship, graph_config);
+                let weight = base_weight * edge.resolution_confidence;
                 Edge {
                     id: format!(
                         "ref:{}->{}:{}",
@@ -604,7 +615,7 @@ impl super::CodememEngine {
                     src: format!("sym:{}", edge.source_qualified_name),
                     dst: format!("sym:{}", edge.target_qualified_name),
                     relationship: edge.relationship,
-                    weight: edge_weight_for(&edge.relationship, graph_config),
+                    weight,
                     valid_from: Some(now),
                     valid_to: None,
                     properties,

--- a/crates/codemem-storage/src/backend.rs
+++ b/crates/codemem-storage/src/backend.rs
@@ -965,6 +965,60 @@ impl StorageBackend for Storage {
             })
             .collect())
     }
+
+    fn store_event_channel(
+        &self,
+        channel: &str,
+        direction: &str,
+        protocol: &str,
+        handler: &str,
+        namespace: &str,
+        description: &str,
+    ) -> Result<(), CodememError> {
+        use crate::cross_repo::EventChannelEntry;
+        let entry = EventChannelEntry {
+            id: format!("ec:{namespace}:{direction}:{channel}"),
+            namespace: namespace.to_string(),
+            channel: channel.to_string(),
+            direction: direction.to_string(),
+            protocol: protocol.to_string(),
+            message_schema: "{}".to_string(),
+            description: description.to_string(),
+            handler: handler.to_string(),
+            spec_file: String::new(),
+        };
+        Storage::upsert_event_channel(self, &entry)
+    }
+
+    fn list_event_channels(
+        &self,
+        namespace: &str,
+    ) -> Result<Vec<(String, String, String, String, String)>, CodememError> {
+        let entries = Storage::get_event_channels_for_namespace(self, namespace)?;
+        Ok(entries
+            .into_iter()
+            .map(|e| (e.channel, e.direction, e.protocol, e.handler, e.description))
+            .collect())
+    }
+
+    fn list_all_event_channels(
+        &self,
+    ) -> Result<Vec<(String, String, String, String, String, String)>, CodememError> {
+        let entries = Storage::get_all_event_channels(self)?;
+        Ok(entries
+            .into_iter()
+            .map(|e| {
+                (
+                    e.channel,
+                    e.direction,
+                    e.protocol,
+                    e.handler,
+                    e.namespace,
+                    e.description,
+                )
+            })
+            .collect())
+    }
 }
 
 #[cfg(test)]

--- a/crates/codemem-storage/src/cross_repo.rs
+++ b/crates/codemem-storage/src/cross_repo.rs
@@ -49,6 +49,20 @@ pub struct ApiClientCallEntry {
     pub library: String,
 }
 
+/// A row in the `event_channels` table.
+#[derive(Debug, Clone)]
+pub struct EventChannelEntry {
+    pub id: String,
+    pub namespace: String,
+    pub channel: String,
+    pub direction: String,
+    pub protocol: String,
+    pub message_schema: String,
+    pub description: String,
+    pub handler: String,
+    pub spec_file: String,
+}
+
 impl Storage {
     // ── Package Registry ─────────────────────────────────────────────────
 
@@ -516,6 +530,97 @@ impl Storage {
                     target: row.get(3)?,
                     caller: row.get(4)?,
                     library: row.get(5)?,
+                })
+            })
+            .storage_err()?;
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.storage_err()?);
+        }
+        Ok(entries)
+    }
+
+    // ── Cross-namespace Edge Queries ─────────────────────────────────────
+
+    // ── Event Channels ───────────────────────────────────────────────
+
+    /// Insert or update an event channel entry.
+    pub fn upsert_event_channel(&self, entry: &EventChannelEntry) -> Result<(), CodememError> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT OR REPLACE INTO event_channels (id, namespace, channel, direction, protocol, message_schema, description, handler, spec_file)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                entry.id,
+                entry.namespace,
+                entry.channel,
+                entry.direction,
+                entry.protocol,
+                entry.message_schema,
+                entry.description,
+                entry.handler,
+                entry.spec_file,
+            ],
+        )
+        .storage_err()?;
+        Ok(())
+    }
+
+    /// Get all event channels for a namespace.
+    pub fn get_event_channels_for_namespace(
+        &self,
+        namespace: &str,
+    ) -> Result<Vec<EventChannelEntry>, CodememError> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, namespace, channel, direction, protocol, message_schema, description, handler, spec_file
+                 FROM event_channels WHERE namespace = ?1",
+            )
+            .storage_err()?;
+        let rows = stmt
+            .query_map(params![namespace], |row| {
+                Ok(EventChannelEntry {
+                    id: row.get(0)?,
+                    namespace: row.get(1)?,
+                    channel: row.get(2)?,
+                    direction: row.get(3)?,
+                    protocol: row.get(4)?,
+                    message_schema: row.get(5)?,
+                    description: row.get(6)?,
+                    handler: row.get(7)?,
+                    spec_file: row.get(8)?,
+                })
+            })
+            .storage_err()?;
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row.storage_err()?);
+        }
+        Ok(entries)
+    }
+
+    /// Get all event channels across all namespaces.
+    pub fn get_all_event_channels(&self) -> Result<Vec<EventChannelEntry>, CodememError> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, namespace, channel, direction, protocol, message_schema, description, handler, spec_file
+                 FROM event_channels",
+            )
+            .storage_err()?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(EventChannelEntry {
+                    id: row.get(0)?,
+                    namespace: row.get(1)?,
+                    channel: row.get(2)?,
+                    direction: row.get(3)?,
+                    protocol: row.get(4)?,
+                    message_schema: row.get(5)?,
+                    description: row.get(6)?,
+                    handler: row.get(7)?,
+                    spec_file: row.get(8)?,
                 })
             })
             .storage_err()?;

--- a/crates/codemem-storage/src/migrations.rs
+++ b/crates/codemem-storage/src/migrations.rs
@@ -74,6 +74,11 @@ const MIGRATIONS: &[Migration] = &[
         description: "Scope context (repo + git_ref)",
         sql: include_str!("migrations/013_scope_context.sql"),
     },
+    Migration {
+        version: 14,
+        description: "Event channels",
+        sql: include_str!("migrations/014_event_channels.sql"),
+    },
 ];
 
 /// Run all pending migrations on the given connection.

--- a/crates/codemem-storage/src/migrations/014_event_channels.sql
+++ b/crates/codemem-storage/src/migrations/014_event_channels.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS event_channels (
+    id          TEXT PRIMARY KEY,
+    namespace   TEXT NOT NULL,
+    channel     TEXT NOT NULL,
+    direction   TEXT NOT NULL,
+    protocol    TEXT DEFAULT '',
+    message_schema TEXT DEFAULT '{}',
+    description TEXT DEFAULT '',
+    handler     TEXT DEFAULT '',
+    spec_file   TEXT DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_channels_ns ON event_channels(namespace);
+CREATE INDEX IF NOT EXISTS idx_event_channels_channel ON event_channels(channel);
+CREATE INDEX IF NOT EXISTS idx_event_channels_dir ON event_channels(direction);


### PR DESCRIPTION
## Summary

Improves graph accuracy across the indexing pipeline and adds cross-service API surface detection for microservice architectures.

### Symbol extraction (9 fixes)
- **Python `async def`** now indexed — was completely invisible
- **Python `from X import Y`** extracts per-name refs (`flask.Flask`, not just `flask`)
- **Rust** enums as scope containers, `macro_definition` extraction, `use X::*` glob handling
- **Go** `var` reclassified from constant to field, go.mod indirect detection fixed
- **TS/JS** abstract classes, `const`/`var` declarations now captured
- **Swift** default visibility corrected to `internal` (was `private`)

### Resolution & edge quality (3 fixes)
- Resolution confidence now **scales edge weights** so low-confidence guesses carry less weight in PageRank
- Symbol embeddings enriched with **typed parameters and return type**
- Resolver suffix boundary check uses `"::"` not single `':'`

### SCIP edge improvements (4 fixes)
- Role priority chain (Imports > Writes > Reads > Calls) — no more duplicate edges
- `is_reference` relationship → **Inherits** edges (class inheritance from SCIP)
- Type-target references → **DependsOn** edges (`fn foo(x: MyStruct)` creates edge to `MyStruct`)
- scip-go READ_ACCESS workaround scoped to lone-flag case only

### Cross-service API surface (new feature)
- **OpenAPI 3.x / Swagger 2.0** spec file parser (YAML + JSON) — 14 tests
- **AsyncAPI 2.x / 3.0** spec file parser with channel/protocol detection
- **Go/Express** endpoint detection from call references (`http.HandleFunc`, `app.get`)
- **Event framework detection** — Kafka, RabbitMQ, Redis, SQS, SNS, NATS patterns + `@KafkaListener` etc.
- **Cross-service edge matching** — `HttpCalls`, `PublishesTo`, `SubscribesTo` relationship types
- **Spec file watcher** — content-based detection (not just filename) triggers re-parse on change
- **New `event_channels` table** (migration 014) with protocol, direction, handler

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 1354 tests pass (14 new)
- [x] Spec parser tests cover: OpenAPI 3.x JSON/YAML, Swagger 2.0, AsyncAPI 2.x/3.0, edge cases
- [x] No breaking changes to existing graph node IDs (new symbol rules are additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)