### PR TITLE
fix: code-mapper pkg: fallback + auto-allow MCP tools

### DIFF
--- a/crates/codemem/assets/agents/code-mapper.md
+++ b/crates/codemem/assets/agents/code-mapper.md
@@ -71,12 +71,16 @@ Identify the active namespace for this project (typically the directory basename
 
 Walk the graph hierarchy top-down to build a complete inventory. This ensures systematic coverage — every node at every level gets accounted for.
 
-**Level 1 — Domain/Workspace**: Get all top-level packages:
+**Level 1 — Domain/Workspace**: Try to get top-level packages. Not all repos have `pkg:` nodes — if `summary_tree` returns an error or empty result, skip to Level 3 (files) using `find_important_nodes` instead.
 ```
 summary_tree { "start_id": "pkg:", "max_depth": 2 }
 ```
+If that fails, use this as your entry point instead:
+```
+find_important_nodes { "top_k": 50, "include_kinds": ["File"] }
+```
 
-**Level 2 — Packages**: For each top-level package, enumerate children:
+**Level 2 — Packages** (skip if no `pkg:` nodes): For each top-level package, enumerate children:
 ```
 graph_traverse { "start_id": "pkg:<name>/", "max_depth": 1, "include_relationships": ["CONTAINS"], "include_kinds": ["Package", "File"] }
 ```
@@ -566,7 +570,7 @@ At least 50% of stored memories should be Decision or Pattern type.
 
 ## Tips
 
-- `summary_tree { "start_id": "pkg:src/" }` for module hierarchy
+- `summary_tree { "start_id": "pkg:src/" }` for module hierarchy (if `pkg:` nodes exist; otherwise use `find_important_nodes`)
 - `find_important_nodes { "top_k": 100 }` for architectural weight
 - `graph_traverse` with `"exclude_kinds": ["chunk"]` for clean call graphs
 - `node_coverage` to batch-check many nodes at once

--- a/crates/codemem/src/cli/commands_init.rs
+++ b/crates/codemem/src/cli/commands_init.rs
@@ -127,6 +127,32 @@ pub(crate) fn cmd_init(project_dir: &std::path::Path, skip_model: bool) -> anyho
             serde_json::json!({})
         };
 
+        // Auto-allow all codemem MCP tools so agents don't prompt for each one
+        let permissions = settings
+            .as_object_mut()
+            .expect("settings initialized as JSON object")
+            .entry("permissions")
+            .or_insert_with(|| serde_json::json!({}));
+        if !permissions.is_object() {
+            *permissions = serde_json::json!({});
+        }
+        let allow_list = permissions
+            .as_object_mut()
+            .unwrap()
+            .entry("allow")
+            .or_insert_with(|| serde_json::json!([]));
+        if let Some(arr) = allow_list.as_array() {
+            let already_has = arr
+                .iter()
+                .any(|v| v.as_str().map(|s| s == "mcp__codemem__*").unwrap_or(false));
+            if !already_has {
+                if let Some(arr) = allow_list.as_array_mut() {
+                    arr.push(serde_json::json!("mcp__codemem__*"));
+                }
+                println!("[permissions] Added mcp__codemem__* to allow list");
+            }
+        }
+
         let hooks = settings
             .as_object_mut()
             .expect("settings initialized as JSON object")


### PR DESCRIPTION
## Summary

- **code-mapper agent**: Falls back to `find_important_nodes` when `pkg:` graph nodes don't exist (not all repos have package nodes)
- **codemem init**: Adds `mcp__codemem__*` to `permissions.allow` in `.claude/settings.json` so code-mapper and other agents don't prompt for every single MCP tool call

## Test plan

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Manual: `codemem init` in a fresh project → verify `permissions.allow` contains `mcp__codemem__*`
- [ ] Manual: Run code-mapper on a repo without `pkg:` nodes → no error, falls back to file-level traversal

🤖 Generated with [Claude Code](https://claude.com/claude-code)