### PR TITLE
fix: correctly check node existence before edge insertion

### DIFF
--- a/crates/codemem-engine/src/persistence/mod.rs
+++ b/crates/codemem-engine/src/persistence/mod.rs
@@ -390,7 +390,7 @@ impl super::CodememEngine {
         }
         let existing_ids: std::collections::HashSet<String> = referenced_ids
             .iter()
-            .filter(|id| self.storage.get_graph_node(id).is_ok())
+            .filter(|id| self.storage.get_graph_node(id).ok().flatten().is_some())
             .map(|id| id.to_string())
             .collect();
 


### PR DESCRIPTION
## Summary

- `get_graph_node()` returns `Result<Option<GraphNode>>` — the previous `.is_ok()` check was true for `Ok(None)` (non-existent nodes), so orphan edges still got through causing FOREIGN KEY constraint failures
- Now uses `.ok().flatten().is_some()` to properly detect missing nodes

## Test plan

- [x] `cargo check` — clean
- [ ] `codemem analyze` — no more FK constraint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)