### PR TITLE
fix(engine): sync HNSW dim from provider/DB instead of trusting configured default

### DIFF
--- a/crates/codemem-engine/src/lib.rs
+++ b/crates/codemem-engine/src/lib.rs
@@ -418,8 +418,41 @@ impl CodememEngine {
     // ── Lazy Initialization ────────────────────────────────────────────
 
     /// Initialize the HNSW vector index: load from disk, run consistency check.
+    ///
+    /// Resolves the vector dimension from the embedding provider (or existing DB
+    /// embeddings) rather than blindly trusting `config.vector.dimensions`. This
+    /// fixes a class of bugs where the HNSW index is allocated with the default
+    /// 768 dims while the actual embeddings are a different size (e.g. 384 for
+    /// bge-small, 1024 for bge-large), causing every insert to fail with a
+    /// dimension-mismatch error.
+    ///
+    /// Source-of-truth priority for the dimension:
+    ///   1. An existing embedding stored in SQLite (the established DB wins —
+    ///      its dim is authoritative because every embedding stored there must
+    ///      match it).
+    ///   2. The embedding provider's `dimensions()` (Candle reads the model's
+    ///      `config.json:hidden_size`; remote providers use
+    ///      `CODEMEM_EMBED_DIMENSIONS` / `config.embedding.dimensions`).
+    ///   3. `config.vector.dimensions` (last-resort default, often 768).
     fn init_vector(&self) -> Mutex<Box<dyn VectorBackend>> {
-        let vector_config = self.config.vector.clone();
+        let mut vector_config = self.config.vector.clone();
+        let configured_dim = vector_config.dimensions;
+
+        if let Some(resolved_dim) = self
+            .peek_db_embedding_dim()
+            .or_else(|| self.peek_provider_dim())
+        {
+            if resolved_dim != configured_dim {
+                tracing::info!(
+                    "Resolved vector dimension to {} (config.vector.dimensions = {})",
+                    resolved_dim,
+                    configured_dim
+                );
+                vector_config.dimensions = resolved_dim;
+            }
+        }
+        let target_dim = vector_config.dimensions;
+
         let mut vector = HnswIndex::new(vector_config.clone())
             .unwrap_or_else(|_| HnswIndex::with_defaults().expect("default vector index"));
 
@@ -428,6 +461,17 @@ impl CodememEngine {
             if index_path.exists() {
                 if let Err(e) = vector.load(&index_path) {
                     tracing::warn!("Stale or corrupt vector index, will rebuild: {e}");
+                } else if vector.actual_dimensions() != target_dim {
+                    tracing::warn!(
+                        "Persisted vector index dim ({}) does not match target dim ({}), rebuilding from DB",
+                        vector.actual_dimensions(),
+                        target_dim
+                    );
+                    // Reset to a fresh, correctly-dimensioned index; the
+                    // consistency check below will repopulate from SQLite.
+                    if let Ok(fresh) = HnswIndex::new(vector_config.clone()) {
+                        vector = fresh;
+                    }
                 }
             }
 
@@ -457,6 +501,36 @@ impl CodememEngine {
         }
 
         Mutex::new(Box::new(vector))
+    }
+
+    /// Peek at the dimension of any embedding already stored in SQLite.
+    ///
+    /// Returns `None` if storage has no embeddings or the lookup errors. This is
+    /// the most authoritative dim source for an established DB — every stored
+    /// embedding shares the same length, so the first one found is sufficient.
+    fn peek_db_embedding_dim(&self) -> Option<usize> {
+        let ids = self.storage.list_memory_ids().ok()?;
+        for id in &ids {
+            if let Ok(Some(emb)) = self.storage.get_embedding(id) {
+                if !emb.is_empty() {
+                    return Some(emb.len());
+                }
+            }
+        }
+        None
+    }
+
+    /// Ask the embedding provider what dimension it produces.
+    ///
+    /// Returns `None` if no provider is configured or initialization fails (e.g.
+    /// model not yet downloaded). This will lazily initialize the embedding
+    /// provider as a side effect — acceptable here because any caller that needs
+    /// the vector index will need embeddings shortly anyway.
+    fn peek_provider_dim(&self) -> Option<usize> {
+        self.lock_embeddings()
+            .ok()
+            .flatten()
+            .map(|p| p.dimensions())
     }
 
     /// Initialize the BM25 index: load from disk or rebuild from memories.

--- a/crates/codemem-engine/src/tests/engine_integration_tests.rs
+++ b/crates/codemem-engine/src/tests/engine_integration_tests.rs
@@ -1,5 +1,6 @@
 use crate::CodememEngine;
 use codemem_core::{Edge, GraphNode, MemoryNode, NodeKind, RelationshipType};
+use codemem_storage::Storage;
 use std::collections::HashMap;
 
 fn make_memory(id: &str, content: &str) -> MemoryNode {
@@ -199,4 +200,80 @@ fn batch_persist_then_single_save() {
         bm25.score("lifetime annotations", "batch-3") > 0.0,
         "batch-3 should be in BM25 index"
     );
+}
+
+// ── Vector dimension sync ───────────────────────────────────────────
+//
+// Regression test for the bug where the HNSW index was always allocated with
+// `VectorConfig::default().dimensions` (768) regardless of the actual embedding
+// size, causing every insert to fail with a dimension-mismatch error when using
+// non-default models (e.g. bge-small at 384, bge-large at 1024). `init_vector`
+// must resolve the dim from existing DB embeddings (or the embedding provider)
+// and rebuild on a saved-index dim mismatch.
+
+const TEST_DIM: usize = 384;
+
+#[test]
+fn init_vector_resolves_dimension_from_existing_db_embedding() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Pre-seed: store a memory + a 384-dim embedding directly into SQLite.
+    {
+        let storage = Storage::open(&db_path).unwrap();
+        let mut mem = MemoryNode::test_default("dimension probe seed");
+        mem.id = "dim-seed".to_string();
+        storage.insert_memory(&mem).unwrap();
+        let embedding: Vec<f32> = (0..TEST_DIM).map(|i| i as f32 * 0.001).collect();
+        storage.store_embedding(&mem.id, &embedding).unwrap();
+    }
+
+    // Re-open via the engine: lazy `init_vector` should pick 384, not the
+    // 768 default in `config.vector.dimensions`.
+    let engine = CodememEngine::from_db_path(&db_path).unwrap();
+    let resolved = engine.with_vector(|v| v.stats().dimensions).unwrap();
+
+    assert_eq!(
+        resolved, TEST_DIM,
+        "init_vector should resolve dim from stored embedding ({TEST_DIM}), not default 768"
+    );
+
+    // The seed embedding should be present in the rebuilt index (count == 1).
+    let count = engine.with_vector(|v| v.stats().count).unwrap();
+    assert_eq!(
+        count, 1,
+        "consistency check should have rebuilt the index from the seeded embedding"
+    );
+}
+
+#[test]
+fn init_vector_dim_matches_provider_or_config_when_db_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Empty DB, no pre-seeded embedding. The resolved vector dim must equal
+    // either the provider's reported dim (when a provider is available) or
+    // the configured dim (when not). Crucially, it must NEVER silently land
+    // on a value that mismatches the provider, because that's the bug.
+    let engine = CodememEngine::from_db_path(&db_path).unwrap();
+    let resolved = engine.with_vector(|v| v.stats().dimensions).unwrap();
+
+    let provider_dim = engine
+        .lock_embeddings()
+        .ok()
+        .flatten()
+        .map(|guard| guard.dimensions());
+
+    if let Some(p_dim) = provider_dim {
+        assert_eq!(
+            resolved, p_dim,
+            "vector dim must equal provider dim — that's the regression"
+        );
+    } else {
+        let configured = engine.config().vector.dimensions;
+        assert_eq!(
+            resolved, configured,
+            "with no provider, dim should fall back to config"
+        );
+    }
 }

--- a/crates/codemem-storage/src/vector.rs
+++ b/crates/codemem-storage/src/vector.rs
@@ -133,6 +133,16 @@ impl HnswIndex {
     pub fn ghost_count(&self) -> usize {
         self.ghost_count
     }
+
+    /// Returns the dimension actually allocated by the underlying usearch index.
+    ///
+    /// This may differ from `self.config.dimensions` after `load()` if the
+    /// persisted index file was created with a different dimension. Callers
+    /// performing dimension reconciliation should compare this against the
+    /// expected dimension and rebuild on mismatch.
+    pub fn actual_dimensions(&self) -> usize {
+        self.index.dimensions()
+    }
 }
 
 impl VectorBackend for HnswIndex {


### PR DESCRIPTION
## Summary

`init_vector` previously allocated the HNSW index with `config.vector.dimensions` (default 768) and never reconciled it against the actual embedding dimension. When the embedding provider produced a different size — e.g. a Candle model whose `config.json:hidden_size` is 384 (bge-small) or 1024 (bge-large), or an Ollama/OpenAI model with a non-768 dim — every insert failed with "Expected 768 dimensions, got N". The vector store appeared "stuck at 768" regardless of any config or env var the user set.

Resolve the dim with a clear source-of-truth priority:

  1. An existing embedding stored in SQLite (authoritative for an established DB — every stored embedding shares the same length).
  2. The embedding provider's `dimensions()` (Candle reads from the model's config.json; remote providers read CODEMEM_EMBED_DIMENSIONS / config.embedding.dimensions).
  3. `config.vector.dimensions` as a last-resort fallback.

Also harden the load path: if a persisted `.idx` file's actual usearch dimension (exposed via the new `HnswIndex::actual_dimensions()` accessor) does not match the resolved target, discard the loaded index and let the existing consistency check rebuild from `list_all_embeddings()`. This handles the migration case where a user changes embedding model on a DB whose `.idx` was built with the old dim.


## Test plan
Tests:
- Regression test: pre-seed a 384-dim embedding into SQLite, open the engine, assert the HNSW index ends up at 384 (not the 768 default).
- Coexistence test: with an empty DB, the resolved dim must match the provider (when one is configured) or fall back to config — never an arbitrary mismatched value.

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Checklist

- [x] Tests added/updated for new behavior
- [x] Documentation updated (if user-facing)
- [x] No new `unwrap()` on mutex/rwlock acquisitions
