### PR TITLE
fix(engine): handle EXDEV when moving SCIP indexer output across filesystems

### DIFF
--- a/crates/codemem-engine/src/index/scip/orchestrate.rs
+++ b/crates/codemem-engine/src/index/scip/orchestrate.rs
@@ -349,10 +349,11 @@ impl ScipOrchestrator {
         if !output_path.exists() {
             let default_output = project_root.join(lang.default_output_file());
             if default_output.exists() {
-                std::fs::rename(&default_output, output_path).map_err(|e| {
+                move_across_filesystems(&default_output, output_path).map_err(|e| {
                     CodememError::ScipOrchestration(format!(
-                        "Failed to move {}: {e}",
-                        default_output.display()
+                        "Failed to move {} to {}: {e}",
+                        default_output.display(),
+                        output_path.display()
                     ))
                 })?;
             }
@@ -411,6 +412,23 @@ impl ScipOrchestrator {
         merged.covered_files.dedup();
 
         Ok(merged)
+    }
+}
+
+/// Move a file from `src` to `dst`, falling back to copy+delete when the two
+/// paths live on different filesystems. `std::fs::rename` maps to the
+/// `rename(2)` syscall which returns `EXDEV` ("Invalid cross-device link")
+/// across mount points — common on Linux when `/tmp` is `tmpfs` and the
+/// project lives under `$HOME` on another filesystem.
+fn move_across_filesystems(src: &Path, dst: &Path) -> std::io::Result<()> {
+    match std::fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+            std::fs::copy(src, dst)?;
+            std::fs::remove_file(src)?;
+            Ok(())
+        }
+        Err(e) => Err(e),
     }
 }
 

--- a/crates/codemem-engine/src/index/tests/scip_orchestrate_tests.rs
+++ b/crates/codemem-engine/src/index/tests/scip_orchestrate_tests.rs
@@ -192,6 +192,19 @@ fn test_merge_empty_files() {
 }
 
 #[test]
+fn test_move_across_filesystems_same_fs() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src.scip");
+    let dst = dir.path().join("dst.scip");
+    std::fs::write(&src, b"payload").unwrap();
+
+    move_across_filesystems(&src, &dst).unwrap();
+
+    assert!(!src.exists());
+    assert_eq!(std::fs::read(&dst).unwrap(), b"payload");
+}
+
+#[test]
 fn test_namespace_substitution() {
     let (prog, args) = parse_shell_command("scip-python index . --project-name=myproject").unwrap();
     assert_eq!(prog, "scip-python");


### PR DESCRIPTION
## Summary


`ScipOrchestrator::run_indexer` creates its temp directory via `tempfile::tempdir()`, which on Linux defaults to `$TMPDIR` / `/tmp`. Many distros (Arch/CachyOS, Fedora, etc.) mount `/tmp` as `tmpfs`, so the temp dir lives on a different filesystem than the project under `$HOME`. SCIP indexers like `rust-analyzer scip .` ignore our requested output path and write `index.scip` into the project root; we then tried to relocate it into the temp dir with `std::fs::rename`.

`rename(2)` cannot cross mount points and returns `EXDEV`, surfacing as:

    SCIP orchestration error: Failed to move
    /home/.../index.scip: Invalid cross-device link (os error 18)

Replace the rename with a small `move_across_filesystems` helper that falls back to `copy` + `remove_file` when `ErrorKind::CrossesDevices` is returned. Same-filesystem moves still take the fast `rename` path. Also include the destination path in the error message so future diagnostics show both ends of the move.

Add a same-filesystem unit test for the helper. Triggering EXDEV portably requires multiple mount points so isn't covered in the test suite, but the fallback path is straightforward `copy`+`remove`.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

## Checklist

- [x] Tests added/updated for new behavior
- [x] Documentation updated (if user-facing)
- [x] No new `unwrap()` on mutex/rwlock acquisitions
